### PR TITLE
fix(authz): [FC-0099] update roles label in `TeamTable`

### DIFF
--- a/src/authz-module/libraries-manager/components/TeamTable.test.tsx
+++ b/src/authz-module/libraries-manager/components/TeamTable.test.tsx
@@ -24,12 +24,12 @@ describe('TeamTable', () => {
   const mockTeamMembers = [
     {
       email: 'alice@example.com',
-      roles: ['Admin', 'Editor'],
+      roles: ['admin', 'editor'],
       username: 'alice',
     },
     {
       email: 'bob@example.com',
-      roles: ['Viewer'],
+      roles: ['viewer'],
       username: 'bob',
     },
   ];
@@ -38,6 +38,38 @@ describe('TeamTable', () => {
     libraryId: 'lib:123',
     canManageTeam: true,
     username: 'alice',
+    roles: [
+      {
+        role: 'admin',
+        permissions: [
+          'delete_library',
+          'publish_library',
+          'manage_library_team',
+        ],
+        userCount: 3,
+        name: 'Admin',
+        description: 'The Admin role',
+      },
+      {
+        role: 'editor',
+        permissions: [
+          'edit_library',
+          'publish_library',
+        ],
+        userCount: 3,
+        name: 'Editor',
+        description: 'The Editor role',
+      },
+      {
+        role: 'viewer',
+        permissions: [
+          'view_library',
+        ],
+        userCount: 3,
+        name: 'Viewer',
+        description: 'The Viewer role',
+      },
+    ],
   };
 
   beforeEach(() => {

--- a/src/authz-module/libraries-manager/components/TeamTable.tsx
+++ b/src/authz-module/libraries-manager/components/TeamTable.tsx
@@ -44,18 +44,12 @@ const NameCell = ({ row }: CellProps) => {
   return row.original.username;
 };
 
-const RolesCell = ({ row }: CellProps) => (row.original.username === SKELETON_ROWS[0].username ? (
-  <Skeleton width="80px" />
-) : (
-  row.original.roles.map((role) => (
-    <Chip key={`${row.original.username}-role-${role}`}>{role}</Chip>
-  ))
-));
-
 const TeamTable = () => {
   const intl = useIntl();
-  const { libraryId, canManageTeam, username } = useLibraryAuthZ();
-
+  const {
+    libraryId, canManageTeam, username, roles,
+  } = useLibraryAuthZ();
+  const roleLabels = roles.reduce((acc, role) => ({ ...acc, [role.role]: role.name }), {} as Record<string, string>);
   // TODO: Display error in the notification system
   const {
     data: teamMembers, isLoading, isError,
@@ -107,7 +101,14 @@ const TeamTable = () => {
           {
             Header: intl.formatMessage(messages['library.authz.team.table.roles']),
             accessor: 'roles',
-            Cell: RolesCell,
+            // eslint-disable-next-line react/no-unstable-nested-components
+            Cell: ({ row }: CellProps) => (row.original.username === SKELETON_ROWS[0].username ? (
+              <Skeleton width="80px" />
+            ) : (
+              row.original.roles.map((role) => (
+                <Chip key={`${row.original.username}-role-${role}`}>{roleLabels[role]}</Chip>
+              ))
+            )),
           },
         ]
       }


### PR DESCRIPTION
# Fix roles label in team table

This Pr update the chip component in the Team Table to display the name of the roles based on the metadata defined here https://github.com/openedx/frontend-app-admin-console/pull/5

**Before**
<img width="1137" height="907" alt="image" src="https://github.com/user-attachments/assets/3625b18b-5918-44c4-8cfe-bb0725e76d5a" />


**After**

<img width="1137" height="907" alt="image" src="https://github.com/user-attachments/assets/c5b41029-0c0a-4dcf-a47b-1c7ac483c42e" />
