### PR TITLE
fix(ulmo): [FC-0099] invalidate PermissionsByRole to update number of user in a role

### DIFF
--- a/src/authz-module/data/hooks.ts
+++ b/src/authz-module/data/hooks.ts
@@ -85,6 +85,7 @@ export const useAssignTeamMembersRole = () => {
     }) => assignTeamMembersRole(data),
     onSettled: (_data, _error, { data: { scope } }) => {
       queryClient.invalidateQueries({ queryKey: authzQueryKeys.teamMembersAll(scope) });
+      queryClient.invalidateQueries({ queryKey: authzQueryKeys.permissionsByRole(scope) });
     },
   });
 };
@@ -104,6 +105,7 @@ export const useRevokeUserRoles = () => {
     }) => revokeUserRoles(data),
     onSettled: (_data, _error, { data: { scope } }) => {
       queryClient.invalidateQueries({ queryKey: authzQueryKeys.teamMembersAll(scope) });
+      queryClient.invalidateQueries({ queryKey: authzQueryKeys.permissionsByRole(scope) });
     },
   });
 };


### PR DESCRIPTION
### Description
Currently the counter of users by role is not being updated when an add/delete role is executed. This is because we are not invalidating the `PermissionsByRole` query that is where this value comes from.

> [!IMPORTANT]
> This is a backport of https://github.com/openedx/frontend-app-admin-console/pull/40 for the ulmo relase branch

**Behavior before change**

[Screencast from 2025-11-19 10-28-02.webm](https://github.com/user-attachments/assets/8bfe244c-2a43-4645-b0fb-2bab67747fcf)


**Behavior after change**

[Screencast from 2025-11-19 10-25-20.webm](https://github.com/user-attachments/assets/2c7dc60a-6b88-4d26-9c8a-6bc913b06633)
