### PR TITLE
refactor: error toast improvement

### DIFF
--- a/src/authz-module/data/hooks.ts
+++ b/src/authz-module/data/hooks.ts
@@ -83,9 +83,11 @@ export const useAssignTeamMembersRole = () => {
     mutationFn: async ({ data }: {
       data: AssignTeamMembersRoleRequest
     }) => assignTeamMembersRole(data),
-    onSettled: (_data, _error, { data: { scope } }) => {
-      queryClient.invalidateQueries({ queryKey: authzQueryKeys.teamMembersAll(scope) });
-      queryClient.invalidateQueries({ queryKey: authzQueryKeys.permissionsByRole(scope) });
+    onSettled: (_data, error, { data: { scope } }) => {
+      if (!error) {
+        queryClient.invalidateQueries({ queryKey: authzQueryKeys.teamMembersAll(scope) });
+        queryClient.invalidateQueries({ queryKey: authzQueryKeys.permissionsByRole(scope) });
+      }
     },
   });
 };

--- a/src/authz-module/libraries-manager/ToastManagerContext.test.tsx
+++ b/src/authz-module/libraries-manager/ToastManagerContext.test.tsx
@@ -213,4 +213,44 @@ describe('ToastManagerContext', () => {
       expect(screen.queryByText('Default delay toast')).not.toBeInTheDocument();
     }, { timeout: 5050 });
   }, 5100);
+
+  it('uses longer delay for error toasts with retry functionality', async () => {
+    const user = userEvent.setup();
+    const retryFn = jest.fn();
+
+    const RetryErrorDelayTestComponent = () => {
+      const { showErrorToast } = useToastManager();
+
+      const handleShowRetryErrorToast = () => showErrorToast(
+        { customAttributes: { httpErrorStatus: 500 } },
+        retryFn,
+      );
+
+      return (
+        <button type="button" onClick={handleShowRetryErrorToast}>
+          Show Retry Error Toast
+        </button>
+      );
+    };
+
+    renderWrapper(
+      <ToastManagerProvider>
+        <RetryErrorDelayTestComponent />
+      </ToastManagerProvider>,
+    );
+
+    const showButton = screen.getByText('Show Retry Error Toast');
+    await user.click(showButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Retry')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    }, { timeout: 5050 });
+
+    expect(logError).toHaveBeenCalled();
+  });
 });

--- a/src/authz-module/libraries-manager/ToastManagerContext.tsx
+++ b/src/authz-module/libraries-manager/ToastManagerContext.tsx
@@ -5,7 +5,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Toast } from '@openedx/paragon';
 import messages from './messages';
-import { DEFAULT_TOAST_DELAY } from './constants';
+import { DEFAULT_TOAST_DELAY, RETRY_TOAST_DELAY } from './constants';
 
 type ToastType = 'success' | 'error' | 'error-retry';
 
@@ -68,11 +68,19 @@ export const ToastManagerProvider = ({ children }: ToastManagerProviderProps) =>
       const errorStatus = error?.customAttributes?.httpErrorStatus;
       const toastConfig = ERROR_TOAST_MAP[errorStatus] || ERROR_TOAST_MAP.DEFAULT;
       const message = intl.formatMessage(messages[toastConfig.messageId], { Bold, Br });
+      /**
+       * For retryable errors, we set a longer delay to give users more time to read the message
+       * and decide to retry, while for non-retryable errors we use the default delay.
+       * Since current toast implementation does not allow disabling the autohide prop,
+       * we use a longer delay for retryable errors to give users more time to read the message.
+       */
+      const delay = toastConfig.type === 'error-retry' && retryFn ? RETRY_TOAST_DELAY : DEFAULT_TOAST_DELAY;
 
       showToast({
         message,
         type: toastConfig.type,
         onRetry: toastConfig.type === 'error-retry' && retryFn ? retryFn : undefined,
+        delay,
       });
     };
 

--- a/src/authz-module/libraries-manager/constants.ts
+++ b/src/authz-module/libraries-manager/constants.ts
@@ -51,6 +51,7 @@ export const libraryPermissions: PermissionMetadata[] = [
 ];
 
 export const DEFAULT_TOAST_DELAY = 5000;
+export const RETRY_TOAST_DELAY = 120_000; // 2 minutes
 export const SKELETON_ROWS = Array.from({ length: 10 }).map(() => ({
   username: 'skeleton',
   name: '',


### PR DESCRIPTION
# Description
Improving error toast with retry function by extending automatic hide delay time to 2 minutes.
The expectation was the toast does not automatically close but since current Toast component from paragon does not allow to disable the automatic hide behavior, we proceed with setting a high time to hide.

Closes https://github.com/openedx/frontend-app-admin-console/issues/50

## How to test it

- `npm run dev` and go to http://apps.local.openedx.io:2025/admin-console/authz/libraries/<your_library_id>
- Click + Add new team member button
- Block the request to http://local.openedx.io:8000/api/authz/v1/roles/users/ ([here is the how to](https://developer.chrome.com/docs/devtools/network-request-blocking), maybe you will need to add a random username and assign a role first to see the request on the devtools network tab)
- Fill the input fields and click save
- Should show one single retry toast, that remains visible (for 2 minutes) until the user either retries the action or explicitly closes it.

