### PR TITLE
fix: change in team members table to use username instead of fullname

### DIFF
--- a/src/authz-module/hooks/useQuerySettings.test.tsx
+++ b/src/authz-module/hooks/useQuerySettings.test.tsx
@@ -47,7 +47,7 @@ describe('useQuerySettings', () => {
       sortBy: [{ id: 'username', desc: false }],
       filters: [
         { id: 'role', value: ['admin', 'editor'] },
-        { id: 'fullName', value: 'john' },
+        { id: 'username', value: 'john' },
       ],
     };
 
@@ -268,7 +268,7 @@ describe('useQuerySettings', () => {
       sortBy: [{ id: 'userRole', desc: true }],
       filters: [
         { id: 'role', value: ['admin', 'editor', 'viewer'] },
-        { id: 'fullName', value: 'test@example.com' },
+        { id: 'username', value: 'test@example.com' },
         { id: 'otherFilter', value: 'ignored' }, // Should be ignored
         { id: 'org', value: ['org1', 'org2'] },
         { id: 'scope', value: ['scope1', 'scope2'] },
@@ -327,7 +327,7 @@ describe('useQuerySettings', () => {
       pageIndex: 0,
       sortBy: [],
       filters: [
-        { id: 'fullName', value: '   ' }, // Whitespace only
+        { id: 'username', value: '   ' }, // Whitespace only
       ],
     };
 
@@ -376,7 +376,7 @@ describe('useQuerySettings', () => {
         pageSize: 10,
         pageIndex: 0,
         sortBy: [],
-        filters: [{ id: 'fullName', value: 'john' }],
+        filters: [{ id: 'username', value: 'john' }],
       });
     });
 
@@ -388,7 +388,7 @@ describe('useQuerySettings', () => {
         pageSize: 10,
         pageIndex: 0,
         sortBy: [],
-        filters: [{ id: 'fullName', value: 'jane' }],
+        filters: [{ id: 'username', value: 'jane' }],
       });
     });
 

--- a/src/authz-module/hooks/useQuerySettings.ts
+++ b/src/authz-module/hooks/useQuerySettings.ts
@@ -44,7 +44,7 @@ export const useQuerySettings = (
     setQuerySettings((prevSettings) => {
       // Extract filters
       const rolesFilter = tableFilters.filters?.find((filter) => filter.id === 'role')?.value?.join(',') ?? '';
-      const searchFilter = tableFilters.filters?.find((filter) => filter.id === 'fullName')?.value ?? '';
+      const searchFilter = tableFilters.filters?.find((filter) => filter.id === 'username')?.value ?? '';
       const organizationsFilter = tableFilters.filters?.find((filter) => filter.id === 'org')?.value?.join(',') ?? '';
       const scopesFilter = tableFilters.filters?.find((filter) => filter.id === 'scope')?.value?.join(',') ?? '';
 

--- a/src/authz-module/team-members/TeamMembersTable.tsx
+++ b/src/authz-module/team-members/TeamMembersTable.tsx
@@ -90,9 +90,9 @@ const TeamMembersTable = ({ presetScope }: TeamMembersTableProps) => {
         columns={
             [
               {
-                id: 'fullName',
+                id: 'username',
                 Header: intl.formatMessage(messages['authz.team.members.table.column.name.title']),
-                accessor: 'fullName',
+                accessor: 'username',
                 Cell: NameCell,
                 filter: 'text',
                 Filter: TextFilter,


### PR DESCRIPTION
### Summary
change in team members table to use username as filter instead of fullname
## Steps to reproduce

- if a user clicks on the name column the table will send to the API the value "username" to sort by

<img width="514" height="163" alt="Screenshot 2026-04-22 at 1 24 06 p m" src="https://github.com/user-attachments/assets/bfe3ff4f-438b-4e9a-b66f-bbfc91433928" />

- if a user searches using the input "Search by Name or Email" the frontend will send the username to the API
<img width="1622" height="559" alt="Screenshot 2026-04-22 at 1 26 37 p m" src="https://github.com/user-attachments/assets/2727d0bf-f58e-4d52-a2ee-7022266a05c9" />

This change was agreed after a discussion on slack at the following [thread](https://openedx.slack.com/archives/C07PRCN6G0N/p1776790058221189)

an it is part of this [task](https://github.com/openedx/frontend-app-admin-console/issues/88)
