### PR TITLE
fix: replaced space for + char to render the filter correctly in the UI

### DIFF
--- a/src/authz-module/authz-home/index.tsx
+++ b/src/authz-module/authz-home/index.tsx
@@ -12,7 +12,7 @@ const AuthzHome = () => {
   const { hash } = useLocation();
   const intl = useIntl();
   const [searchParams] = useSearchParams();
-  const presetScope = searchParams.get('scope') || undefined;
+  const presetScope = searchParams.get('scope')?.replace(/\s/g, '+') || undefined;
 
   const pageTitle = intl.formatMessage(messages['authz.manage.page.title']);
 

--- a/src/authz-module/authz-home/index.tsx
+++ b/src/authz-module/authz-home/index.tsx
@@ -12,6 +12,10 @@ const AuthzHome = () => {
   const { hash } = useLocation();
   const intl = useIntl();
   const [searchParams] = useSearchParams();
+
+  /* In the authoring repository the scope is encoded but this is to Replace spaces with '+'
+     to match URL encoding format in case the 'scope' parameter is provided with spaces instead of '+'
+  */
   const presetScope = searchParams.get('scope')?.replace(/\s/g, '+') || undefined;
 
   const pageTitle = intl.formatMessage(messages['authz.manage.page.title']);


### PR DESCRIPTION
### Issue

<img width="1190" height="709" alt="image" src="https://github.com/user-attachments/assets/f76e65bc-19ec-4287-b719-f5fc7cb10c68" />

### Description

The filter is showing spaces instead of "+" chars.
for example after the redirection to admin console this  string 
course-v1:TestOrg+101+2025_T1
is received as
course-v1:TestOrg 101 2025_T1

### Fix
- I made a change to keep the "+" char when the param is received

NOTE: after debugging I saw that we send the correct data

<img width="429" height="152" alt="Screenshot 2026-04-23 at 3 56 05 p m" src="https://github.com/user-attachments/assets/b98ec61c-755c-4a08-96b0-0b154563b493" />
Backend print in AUTHZ view
<img width="494" height="43" alt="Screenshot 2026-04-23 at 3 57 00 p m" src="https://github.com/user-attachments/assets/f525b21d-ac35-40ec-b892-48de974fe60a" />

UI
<img width="429" height="112" alt="Screenshot 2026-04-23 at 4 05 30 p m" src="https://github.com/user-attachments/assets/36d98ff5-f7fe-4f08-8e17-ae5fbb3d39b9" />


