### PR TITLE
fix: keys and props fixed to avoid console warnings

### DIFF
--- a/src/authz-module/components/ResourceTooltip.tsx
+++ b/src/authz-module/components/ResourceTooltip.tsx
@@ -17,14 +17,14 @@ const ResourceTooltip = ({ resourceGroup }:ResourceTooltipProps) => (
           <p className="small">{resourceGroup.description}</p>
           <ul className="small">
             {resourceGroup.permissions.map(permission => (
-              <li><b>{permission.label.trim()}:</b> {permission.description}</li>
+              <li key={permission.key}><b>{permission.label.trim()}:</b> {permission.description}</li>
             ))}
           </ul>
         </Popover.Content>
       </Popover>
     )}
   >
-    <Icon className="d-inline-block text-gray-300 ml-2 my-auto" size="inline" src={Info} />
+    <Icon className="d-inline-block text-gray-300 ml-2 my-auto" src={Info} />
   </OverlayTrigger>
 );
 

--- a/src/authz-module/components/TableCells.tsx
+++ b/src/authz-module/components/TableCells.tsx
@@ -108,11 +108,14 @@ const ScopeCell = ({ row }: CellProps) => {
   );
 };
 
-const RoleCell = ({ value, cell }: ExtendedCellProps) => (
-  <span {...cell.getCellProps({ 'data-role': MAP_ROLE_KEY_TO_LABEL[value] || '' })}>
-    {MAP_ROLE_KEY_TO_LABEL[value] || ''}
-  </span>
-);
+const RoleCell = ({ value, cell }: ExtendedCellProps) => {
+  const { key, ...cellProps } = cell.getCellProps({ 'data-role': MAP_ROLE_KEY_TO_LABEL[value] || '' });
+  return (
+    <span key={key} {...cellProps}>
+      {MAP_ROLE_KEY_TO_LABEL[value] || ''}
+    </span>
+  );
+};
 
 const PermissionsCell = ({ row }: CellProps) => {
   const { formatMessage } = useIntl();


### PR DESCRIPTION
### Description
console warnings were found because of a missing key and bad passing props.
this is part of the new development of Roles and permissions management