### PR TITLE
fix: redirecting to team members when there are not roles left after removing the last one

### DIFF
--- a/src/authz-module/audit-user/index.tsx
+++ b/src/authz-module/audit-user/index.tsx
@@ -202,6 +202,9 @@ const AuditUserPage = () => {
             type: 'success',
           });
           handleCloseConfirmDeletionModal();
+          if (remainingRolesCount === 0) {
+            navigate(AUTHZ_HOME_PATH);
+          }
         },
         onError: (error, retryVariables) => {
           showErrorToast(error, () => runRevokeRole(retryVariables));


### PR DESCRIPTION
## Description
Adding validation to redirect to team members table after being on the audit user page and removing the last assigned role to the user.

Scenario: Removing the last role redirects to Team Members
Given I open the audit view for a user with only one role assignment
When I click the trash icon and confirm
Then a success toast appears, I am redirected to the Team Members table, and the user no longer appears there

It closes https://github.com/openedx/frontend-app-admin-console/issues/147

### Demo
https://github.com/user-attachments/assets/77be32bc-24a0-454e-b869-b6664a9d1cde

### How to test it

1. Go to a specific user page with roles assigned `http://apps.local.openedx.io:2025/admin-console/authz/user/:userId`
2. Remove all the roles assigned.
3. Once the last role is removed, it must redirect to the team members view.
