### PR TITLE
refactor: remove course taxonomy permissions

### DIFF
--- a/src/authz-module/constants.ts
+++ b/src/authz-module/constants.ts
@@ -67,7 +67,6 @@ export const CONTENT_COURSE_PERMISSIONS = {
   MANAGE_COURSE_GROUP_CONFIGURATION: 'courses.manage_group_configurations',
 
   MANAGE_COURSE_TAGS: 'courses.manage_tags',
-  MANAGE_COURSE_TAXONOMIES: 'courses.manage_taxonomies',
 
   MANAGE_COURSE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
   MANAGE_COURSE_CERTIFICATES: 'courses.manage_certificates',
@@ -117,7 +116,7 @@ export const libraryPermissions: PermissionMetadata[] = [
 
 export const courseResourceTypes: ResourceMetadata[] = [
   {
-    key: 'course_tags_taxonomies', label: 'Tags & taxonomies', description: 'Permissions for managing tags and taxonomies used to organize course content.', icon: LocalOffer,
+    key: 'course_tags_taxonomies', label: 'Tags', description: 'Permissions for managing tags used to organize course content.', icon: LocalOffer,
   },
   {
     key: 'course_updates_handouts', label: 'Course updates & handouts', description: 'Permissions for viewing and managing course updates and handouts that are visible to learners.', icon: Sync,
@@ -327,13 +326,6 @@ export const coursePermissions: PermissionMetadata[] = [
     label: 'Manage tags',
     icon: Settings,
   },
-  {
-    key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TAXONOMIES,
-    resource: 'course_tags_taxonomies',
-    description: 'Create, edit, and delete taxonomies used to organize course content.',
-    label: 'Manage taxonomies',
-    icon: Settings,
-  },
 
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_ADVANCED_SETTINGS,
@@ -423,7 +415,6 @@ export const rolesObject = [
       CONTENT_COURSE_PERMISSIONS.EXPORT_COURSE,
       CONTENT_COURSE_PERMISSIONS.EXPORT_COURSE_TAGS,
       CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TEAM,
-      CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TAXONOMIES,
     ],
     userCount: 1,
     name: 'Course Admin',

--- a/src/authz-module/roles-permissions/course/constants.ts
+++ b/src/authz-module/roles-permissions/course/constants.ts
@@ -43,7 +43,6 @@ export const CONTENT_COURSE_PERMISSIONS = {
   MANAGE_COURSE_GROUP_CONFIGURATION: 'courses.manage_group_configurations',
 
   MANAGE_COURSE_TAGS: 'courses.manage_tags',
-  MANAGE_COURSE_TAXONOMIES: 'courses.manage_taxonomies',
 
   MANAGE_COURSE_ADVANCED_SETTINGS: 'courses.manage_advanced_settings',
   MANAGE_COURSE_CERTIFICATES: 'courses.manage_certificates',
@@ -82,7 +81,7 @@ export const courseResourceTypes: ResourceMetadata[] = [
     key: 'course_team_group', label: 'Course team & groups', description: 'Permissions for viewing and managing the course team, learner groups, and group configurations.', icon: Group,
   },
   {
-    key: 'course_tags_taxonomies', label: 'Tags & taxonomies', description: 'Permissions for managing tags and taxonomies used to organize course content.', icon: LocalOffer,
+    key: 'course_tags_taxonomies', label: 'Tags', description: 'Permissions for managing tags used to organize course content.', icon: LocalOffer,
   },
   {
     key: 'course_advanced_certificates', label: 'Advanced & certificates', description: 'Permissions for managing advanced course settings and course certificates.', icon: CheckCircle,
@@ -243,12 +242,6 @@ export const coursePermissions: PermissionMetadata[] = [
     description: 'Create, edit, delete tags.',
     label: 'Manage tags',
   },
-  {
-    key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TAXONOMIES,
-    resource: 'course_tags_taxonomies',
-    description: 'Create, edit, delete taxonomies.',
-    label: 'Manage taxonomies',
-  },
 
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_ADVANCED_SETTINGS,
@@ -332,7 +325,6 @@ export const rolesObject = [
       CONTENT_COURSE_PERMISSIONS.EXPORT_COURSE,
       CONTENT_COURSE_PERMISSIONS.EXPORT_COURSE_TAGS,
       CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TEAM,
-      CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TAXONOMIES,
     ],
     userCount: 1,
     name: 'Course Admin',


### PR DESCRIPTION
Removes the `manage_taxonomies` permission from the UI as decided in https://github.com/openedx/openedx-authz/issues/309

> The course admin can manage tags, but can't manage taxonomy (it is not related to a course role); the content tagging will have its own permissions.

Closes https://github.com/openedx/openedx-authz/issues/309

## Changes

- Removed `MANAGE_COURSE_TAXONOMIES` from the `CONTENT_COURSE_PERMISSIONS` enum
- Removed the "Manage taxonomies" entry from the permissions list rendered in the UI
- Removed `MANAGE_COURSE_TAXONOMIES` from the `course_admin` role definition
- Updated the "Tags & taxonomies" resource group label to "Tags"

Applied to both `authz-module/constants.ts` and `roles-permissions/course/constants.ts`.

### Screenshot
<img width="1858" height="860" alt="image" src="https://github.com/user-attachments/assets/a9fdb340-7b93-4bcf-8781-5dc05f38fd2e" />

## Pending

The permission also needs to be removed from `openedx-authz` (constant definition and role policy assignment).

