### PR TITLE
fix: restore icons and labels in permissions after consolidation

### DIFF
--- a/src/authz-module/roles-permissions/course/constants.ts
+++ b/src/authz-module/roles-permissions/course/constants.ts
@@ -10,6 +10,14 @@ import {
   Download,
   DrawShapes,
   CheckCircle,
+  RemoveRedEye,
+  Plus,
+  EditOutline,
+  DownloadDone,
+  Settings,
+  Checklist,
+  Delete,
+  Upload,
   Award,
 } from '@openedx/paragon/icons';
 
@@ -103,24 +111,28 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_access_content',
     description: 'View course in the course list, access the course outline in read only mode, includes the "View Live" entry point.',
     label: 'View course',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.CREATE_COURSE,
     resource: 'course_access_content',
     description: 'Create a new course in Studio.',
     label: 'Create course',
+    icon: Plus,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EDIT_COURSE_CONTENT,
     resource: 'course_access_content',
     description: 'Edit course content, outline, units, components.',
     label: 'Edit course content',
+    icon: EditOutline,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.PUBLISH_COURSE_CONTENT,
     resource: 'course_access_content',
     description: 'Publish course content.',
     label: 'Publish course content',
+    icon: DownloadDone,
   },
 
   {
@@ -128,6 +140,7 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_library_updates',
     description: 'Accept or reject library updates in Studio.',
     label: 'Review library updates',
+    icon: Checklist,
   },
 
   {
@@ -135,12 +148,14 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_updates_handouts',
     description: 'View course updates and handouts.',
     label: 'View course updates',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_UPDATES,
     resource: 'course_updates_handouts',
     description: 'Manage course updates and handouts, create, edit, delete.',
     label: 'Manage course updates',
+    icon: Settings,
   },
 
   {
@@ -148,12 +163,14 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_pages_resources',
     description: 'View Pages and Resources.',
     label: 'View pages & resources',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_PAGES_RESOURCES,
     resource: 'course_pages_resources',
     description: 'Edit Pages and Resources, including toggles and content managed from that section.',
     label: 'Manage pages & resources',
+    icon: Settings,
   },
 
   {
@@ -161,24 +178,28 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_files',
     description: 'View the Files page.',
     label: 'View files',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.CREATE_COURSE_FILES,
     resource: 'course_files',
     description: 'Upload files.',
     label: 'Create files',
+    icon: Plus,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EDIT_COURSE_FILES,
     resource: 'course_files',
     description: 'Non destructive file actions, for example lock or unlock, exact actions depend on implementation.',
     label: 'Edit files',
+    icon: EditOutline,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.DELETE_COURSE_FILES,
     resource: 'course_files',
     description: 'Delete files.',
     label: 'Delete files',
+    icon: Delete,
   },
 
   {
@@ -186,24 +207,28 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_schedule_details',
     description: 'View course schedule.',
     label: 'View schedule',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EDIT_COURSE_SCHEDULE,
     resource: 'course_schedule_details',
     description: 'Edit course schedule.',
     label: 'Edit schedule',
+    icon: EditOutline,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.VIEW_COURSE_DETAILS,
     resource: 'course_schedule_details',
     description: 'View course details.',
     label: 'View course details',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EDIT_COURSE_DETAILS,
     resource: 'course_schedule_details',
     description: 'Edit course details, includes Course Summary, Course Pacing, Course Details, Course Pre requisite.',
     label: 'Edit course details',
+    icon: EditOutline,
   },
 
   {
@@ -211,12 +236,14 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_grading',
     description: 'View grading settings page.',
     label: 'View grading settings',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EDIT_COURSE_GRADING_SETTINGS,
     resource: 'course_grading',
     description: 'Edit grading settings.',
     label: 'Edit grading settings',
+    icon: EditOutline,
   },
 
   {
@@ -224,18 +251,21 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_team_group',
     description: 'View the course team roster.',
     label: 'View course team',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TEAM,
     resource: 'course_team_group',
     description: 'Edit course team membership and roles.',
     label: 'Manage course team',
+    icon: Settings,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_GROUP_CONFIGURATION,
     resource: 'course_team_group',
     description: 'Manage content groups.',
     label: 'Manage group configuration',
+    icon: Settings,
   },
 
   {
@@ -243,6 +273,7 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_tags_taxonomies',
     description: 'Create, edit, delete tags.',
     label: 'Manage tags',
+    icon: Settings,
   },
 
   {
@@ -250,12 +281,14 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_advanced_certificates',
     description: 'Access and edit Advanced Settings.',
     label: 'Manage advanced settings',
+    icon: Settings,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_CERTIFICATES,
     resource: 'course_advanced_certificates',
     description: 'Access and edit Certificates.',
     label: 'Manage certificates',
+    icon: Settings,
   },
 
   {
@@ -263,18 +296,21 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_import_export',
     description: 'Show Import in Studio, this is treated as a high privilege action and effectively implies most authoring permissions.',
     label: 'Import course',
+    icon: Download,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EXPORT_COURSE,
     resource: 'course_import_export',
     description: 'Show Export in Studio.',
     label: 'Export course',
+    icon: Upload,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.EXPORT_COURSE_TAGS,
     resource: 'course_import_export',
     description: 'Export tags.',
     label: 'Export tags',
+    icon: Upload,
   },
 
   {
@@ -282,14 +318,15 @@ export const coursePermissions: PermissionMetadata[] = [
     resource: 'course_other',
     description: 'View checklists.',
     label: 'View checklists',
+    icon: RemoveRedEye,
   },
   {
     key: CONTENT_COURSE_PERMISSIONS.VIEW_COURSE_GLOBAL_STAFF_SUPER_ADMINS,
     resource: 'course_other',
     description: 'Allow course or library admins to view the list of global Staff and Super Admin users.',
     label: 'View global staff & super admins',
+    icon: RemoveRedEye,
   },
-
 ];
 
 // roles hardcoded, todo: need to add the constants from above in order to merge the different permissions array.

--- a/src/authz-module/roles-permissions/library/constants.ts
+++ b/src/authz-module/roles-permissions/library/constants.ts
@@ -3,6 +3,14 @@ import {
 } from '@src/types';
 import {
   Group, CollectionsBookmark, Notes, AutoAwesomeMosaic,
+  RemoveRedEye,
+  Settings,
+  DownloadDone,
+  Plus,
+  EditOutline,
+  Delete,
+  SpinnerIcon,
+  FileDownload,
 } from '@openedx/paragon/icons';
 
 export const CONTENT_LIBRARY_PERMISSIONS = {
@@ -58,27 +66,48 @@ export const libraryResourceTypes: ResourceMetadata[] = [
 ];
 
 export const libraryPermissions: PermissionMetadata[] = [
-  { key: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY, resource: 'library', description: 'View content, search, filter, and sort within the library.' },
   {
-    key: CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TAGS, resource: 'library', description: 'Add or remove tags from content.', label: 'Manage Tags',
+    key: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY, resource: 'library', label: 'View', description: 'See the library in Studio and access its content in read-only mode.', icon: RemoveRedEye,
   },
-  { key: CONTENT_LIBRARY_PERMISSIONS.PUBLISH_LIBRARY_CONTENT, resource: 'library', description: 'Allows the user to publish the library and all its contents.' },
-
-  { key: CONTENT_LIBRARY_PERMISSIONS.CREATE_LIBRARY_CONTENT, resource: 'library_content', description: 'Create content within the library.' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.EDIT_LIBRARY_CONTENT, resource: 'library_content', description: 'Edit content in draft mode' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.DELETE_LIBRARY_CONTENT, resource: 'library_content', description: 'Delete content within the library.' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.PUBLISH_LIBRARY_CONTENT, resource: 'library_content', description: 'Publish content, making it available for reuse' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.REUSE_LIBRARY_CONTENT, resource: 'library_content', description: 'Reuse published content within a course.' },
   {
-    key: CONTENT_LIBRARY_PERMISSIONS.IMPORT_LIBRARY_CONTENT, resource: 'library_content', description: 'Import content from courses.', label: 'Import Content from Course',
+    key: CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TAGS, resource: 'library', label: 'Manage tag', description: 'Create, edit, and delete tags on this library.', icon: Settings,
   },
-
-  { key: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM, resource: 'library_team', description: 'View the list of users who have access to the library.' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TEAM, resource: 'library_team', description: 'Add, remove, and assign roles to users within the library.' },
-
-  { key: CONTENT_LIBRARY_PERMISSIONS.CREATE_LIBRARY_COLLECTION, resource: 'library_collection', description: 'Create new collections within a library.' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.EDIT_LIBRARY_COLLECTION, resource: 'library_collection', description: 'Add or remove content from existing collections.' },
-  { key: CONTENT_LIBRARY_PERMISSIONS.DELETE_LIBRARY_COLLECTION, resource: 'library_collection', description: 'Delete entire collections from the library.' },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.DELETE_LIBRARY, resource: 'library', label: 'Publish', description: 'Publish the library to make it available for use in courses.', icon: DownloadDone,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.CREATE_LIBRARY_CONTENT, resource: 'library_content', label: 'Create', description: 'Create new content items in the library.', icon: Plus,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.EDIT_LIBRARY_CONTENT, resource: 'library_content', label: 'Edit', description: 'Edit existing content items in the library.', icon: EditOutline,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.DELETE_LIBRARY_CONTENT, resource: 'library_content', label: 'Delete', description: 'Permanently remove content items from the library.', icon: Delete,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.PUBLISH_LIBRARY_CONTENT, resource: 'library_content', label: 'Publish', description: 'Publish individual content items to make them available for reuse in courses.', icon: DownloadDone,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.REUSE_LIBRARY_CONTENT, resource: 'library_content', label: 'Reuse', description: 'Add published content from this library to a course.', icon: SpinnerIcon,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.IMPORT_LIBRARY_CONTENT, resource: 'library_content', label: 'Import Content from Course', description: ' Import content from an existing course into this library.', icon: FileDownload,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM, resource: 'library_team', label: 'View', description: 'See the list of users with a role assigned to this library.', icon: RemoveRedEye,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TEAM, resource: 'library_team', label: 'Manage', description: 'Add, change, or remove role assignments for this library from the Roles and Permissions console.', icon: Settings,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.CREATE_LIBRARY_COLLECTION, resource: 'library_collection', label: 'View', description: 'Create new collections to organize content within the library.', icon: RemoveRedEye,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.EDIT_LIBRARY_COLLECTION, resource: 'library_collection', label: 'Publish', description: 'Update the name and contents of existing collections.', icon: EditOutline,
+  },
+  {
+    key: CONTENT_LIBRARY_PERMISSIONS.DELETE_LIBRARY_COLLECTION, resource: 'library_collection', label: 'Edit', description: 'Permanently remove collections from the library.', icon: EditOutline,
+  },
 ];
 
 export const rolesLibraryObject: Role[] = [


### PR DESCRIPTION
After the type validation and permission consolidation the icons and labels where not displayed in the collapsible for the user view this PR restore them and update some of the text to match  the description in the original issue https://github.com/openedx/frontend-app-admin-console/issues/87

**Error**
<img width="1657" height="292" alt="image" src="https://github.com/user-attachments/assets/394cb17e-7c1d-4a99-b998-8e98ab5a197b" />


**Solved**

<img width="1657" height="292" alt="image" src="https://github.com/user-attachments/assets/33a61179-fe40-40d5-88d6-a10cadc197d9" />
