### PR TITLE
refactor: centralize role/route constants and derive role maps from metadata

### DIFF
--- a/src/authz-module/audit-user/index.tsx
+++ b/src/authz-module/audit-user/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@openedx/paragon';
 import TableFooter from '@src/authz-module/components/TableFooter/TableFooter';
 import {
-  AUTHZ_HOME_PATH, TABLE_DEFAULT_PAGE_SIZE,
+  ROUTES, TABLE_DEFAULT_PAGE_SIZE,
 } from '@src/authz-module/constants';
 import AuthZLayout from '@src/authz-module/components/AuthZLayout';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -94,7 +94,7 @@ const AuditUserPage = () => {
   useEffect(() => {
     if (!user && !isLoadingUser) {
       if (!isErrorUser || getHttpErrorStatus(errorUser) === 404) {
-        navigate(AUTHZ_HOME_PATH);
+        navigate(ROUTES.HOME_PATH);
       }
     }
   }, [user, isLoadingUser, navigate, isErrorUser, errorUser]);
@@ -109,7 +109,7 @@ const AuditUserPage = () => {
   const navLinks = useMemo(() => [
     {
       label: formatMessage(baseMessages['authz.management.home.nav.link']),
-      to: AUTHZ_HOME_PATH,
+      to: ROUTES.HOME_PATH,
     },
   ], [formatMessage]);
 
@@ -216,7 +216,7 @@ const AuditUserPage = () => {
           });
           handleCloseConfirmDeletionModal();
           if (remainingRolesCount === 0) {
-            navigate(AUTHZ_HOME_PATH);
+            navigate(ROUTES.HOME_PATH);
           }
         },
         onError: (error, retryVariables) => {

--- a/src/authz-module/components/PermissionTable.test.tsx
+++ b/src/authz-module/components/PermissionTable.test.tsx
@@ -10,7 +10,7 @@ const mockRoles: Role[] = [
     userCount: 0,
     permissions: [],
     role: '',
-    contextType: '',
+    contextType: 'course',
     scope: '',
   },
   {
@@ -19,7 +19,7 @@ const mockRoles: Role[] = [
     userCount: 0,
     permissions: [],
     role: '',
-    contextType: '',
+    contextType: 'course',
     scope: '',
   },
   {
@@ -28,7 +28,7 @@ const mockRoles: Role[] = [
     userCount: 0,
     permissions: [],
     role: '',
-    contextType: '',
+    contextType: 'course',
     scope: '',
   },
 ];

--- a/src/authz-module/components/RenderAdminRole.test.tsx
+++ b/src/authz-module/components/RenderAdminRole.test.tsx
@@ -6,7 +6,7 @@ import RenderAdminRole from './RenderAdminRole';
 describe('RenderAdminRole', () => {
   const adminRole = 'course_admin';
   const superuserRole = 'django.superuser';
-  const staffRole = 'django.globalstaff';
+  const staffRole = 'django.staff';
   const instructorRole = 'instructor';
   const emptyRole = '';
   const mixedCaseAdminRole = 'Library_Admin';

--- a/src/authz-module/components/RenderAdminRole.test.tsx
+++ b/src/authz-module/components/RenderAdminRole.test.tsx
@@ -27,13 +27,13 @@ describe('RenderAdminRole', () => {
     expect(container.querySelector('.mb-0')).toBeInTheDocument();
   });
 
-  it('displays admin message for roles containing admin', () => {
-    renderWrapper(<RenderAdminRole role={adminRole} />);
+  it('displays admin message for superuser role', () => {
+    renderWrapper(<RenderAdminRole role={superuserRole} />);
     expect(screen.getByText(/super admins have full access/i)).toBeInTheDocument();
   });
 
-  it('displays staff message for superuser role', () => {
-    renderWrapper(<RenderAdminRole role={superuserRole} />);
+  it('displays staff message for non-django admin roles', () => {
+    renderWrapper(<RenderAdminRole role={adminRole} />);
     expect(screen.getByText(/global staff have access/i)).toBeInTheDocument();
   });
 
@@ -57,9 +57,9 @@ describe('RenderAdminRole', () => {
     expect(screen.getByText(/global staff have access/i)).toBeInTheDocument();
   });
 
-  it('displays admin message for mixed case admin role', () => {
+  it('displays staff message for mixed case admin role', () => {
     renderWrapper(<RenderAdminRole role={mixedCaseAdminRole} />);
-    expect(screen.getByText(/super admins have full access/i)).toBeInTheDocument();
+    expect(screen.getByText(/global staff have access/i)).toBeInTheDocument();
   });
 
   it('displays staff message for regular role without admin', () => {

--- a/src/authz-module/components/RenderAdminRole.tsx
+++ b/src/authz-module/components/RenderAdminRole.tsx
@@ -1,4 +1,5 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { SUPERUSER_ROLE } from '@src/authz-module/constants';
 import messages from '@src/authz-module/audit-user/messages';
 
 interface RenderAdminRoleProps {
@@ -7,8 +8,7 @@ interface RenderAdminRoleProps {
 
 const RenderAdminRole = ({ role }: RenderAdminRoleProps) => {
   const intl = useIntl();
-  // Determine which message to show based on role
-  const messageKey = role?.toLowerCase().includes('admin')
+  const messageKey = role === SUPERUSER_ROLE
     ? 'authz.user.table.permissions.role.admin'
     : 'authz.user.table.permissions.role.staff';
 

--- a/src/authz-module/components/RenderAdminRole.tsx
+++ b/src/authz-module/components/RenderAdminRole.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { SUPERUSER_ROLE } from '@src/authz-module/constants';
+import { SUPERUSER_ROLE } from '@src/authz-module/roles-permissions';
 import messages from '@src/authz-module/audit-user/messages';
 
 interface RenderAdminRoleProps {

--- a/src/authz-module/components/TableCells.test.tsx
+++ b/src/authz-module/components/TableCells.test.tsx
@@ -516,7 +516,7 @@ describe('TableCells Components', () => {
       original: {
         role: 'library_admin',
         org: 'Test Org',
-        scope: 'Test Scope',
+        scope: 'lib:Org:TestScope',
         permissionCount: 1,
         canManageScope: true,
       },
@@ -538,7 +538,7 @@ describe('TableCells Components', () => {
       expect(deleteButton).toBeInTheDocument();
 
       await user.click(deleteButton);
-      expect(mockOnClickDeleteButton).toHaveBeenCalledWith({ name: 'Library Admin', role: 'library_admin', scope: 'Test Scope' });
+      expect(mockOnClickDeleteButton).toHaveBeenCalledWith({ name: 'Library Admin', role: 'library_admin', scope: 'lib:Org:TestScope' });
     });
 
     it('renders a disabled delete icon for admin roles when isUserAuthenticatedPage is true', () => {
@@ -586,7 +586,7 @@ describe('TableCells Components', () => {
         original: {
           role: 'django.superuser',
           org: 'Test Org',
-          scope: 'Test Scope',
+          scope: 'lib:Org:TestScope',
           permissionCount: 1,
         },
       };
@@ -610,7 +610,7 @@ describe('TableCells Components', () => {
       });
       const customRow = {
         original: {
-          ...baseRow,
+          ...baseRow.original,
           canManageScope: false,
         },
       };

--- a/src/authz-module/components/TableCells.test.tsx
+++ b/src/authz-module/components/TableCells.test.tsx
@@ -364,7 +364,7 @@ describe('TableCells Components', () => {
         row: {
           id: '0',
           original: {
-            role: 'django.globalstaff', org: 'Test Org', scope: 'Test Scope', permissionCount: 1,
+            role: 'django.staff', org: 'Test Org', scope: 'Test Scope', permissionCount: 1,
           },
         },
         column: { id: 'org' },
@@ -420,7 +420,7 @@ describe('TableCells Components', () => {
         row: {
           id: '0',
           original: {
-            role: 'django.globalstaff', org: 'Test Org', scope: 'Test Scope', permissionCount: 1,
+            role: 'django.staff', org: 'Test Org', scope: 'Test Scope', permissionCount: 1,
           },
         },
         column: { id: 'scope' },
@@ -476,7 +476,7 @@ describe('TableCells Components', () => {
         row: {
           id: '0',
           original: {
-            role: 'django.globalstaff',
+            role: 'django.staff',
             permissionCount: 5,
             org: 'Test Org',
             scope: 'Test Scope',

--- a/src/authz-module/components/TableCells.test.tsx
+++ b/src/authz-module/components/TableCells.test.tsx
@@ -260,7 +260,7 @@ describe('TableCells Components', () => {
       const viewButton = screen.getByRole('button', { name: /view/i });
       await user.click(viewButton);
 
-      expect(mockNavigate).toHaveBeenCalledWith('/authz/user/user+with@special.chars');
+      expect(mockNavigate).toHaveBeenCalledWith(`/authz/user/${encodeURIComponent('user+with@special.chars')}`);
     });
 
     it('disables the view action and shows a tooltip when course authoring is disabled for the course', async () => {

--- a/src/authz-module/components/TableCells.tsx
+++ b/src/authz-module/components/TableCells.tsx
@@ -99,7 +99,7 @@ const ViewActionCell = ({ row, isCourseEnabled }: CellProps & Partial<ViewAction
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
   const viewPath = buildUserPath(row.original.username ?? '');
-  const isCourseScope = !row.original.role?.startsWith('lib') && !DJANGO_MANAGED_ROLES.includes(row.original.role);
+  const isCourseScope = getScopeContextType(row.original.scope) === 'course' && !DJANGO_MANAGED_ROLES.includes(row.original.role);
   const isDisabled = isCourseEnabled !== undefined && isCourseScope && !isCourseEnabled(row.original.scope);
 
   if (isDisabled) {
@@ -268,7 +268,7 @@ const ActionsCell = ({
     );
   }
 
-  const isCourseScope = !role?.startsWith('lib');
+  const isCourseScope = getScopeContextType(row.original.scope) === 'course';
   const isCourseAuthoringDisabled = isCourseEnabled !== undefined
     && isCourseScope && !isCourseEnabled(row.original.scope);
 

--- a/src/authz-module/components/TableCells.tsx
+++ b/src/authz-module/components/TableCells.tsx
@@ -9,7 +9,8 @@ import { UserRoleWithPermissions, RoleToDelete } from '@src/types';
 import { useNavigate } from 'react-router-dom';
 import { useContext, useMemo, type ComponentProps } from 'react';
 import {
-  ADMIN_ROLES, DJANGO_MANAGED_ROLES, MAP_ROLE_KEY_TO_LABEL,
+  ADMIN_ROLES, buildUserPath, DJANGO_MANAGED_ROLES, getScopeContextType,
+  MAP_ROLE_KEY_TO_LABEL, SUPERUSER_ROLE,
 } from '@src/authz-module/constants';
 import {
   Icon, IconButton, OverlayTrigger, Tooltip, DataTableContext,
@@ -97,7 +98,7 @@ const NameCell = ({ row }: CellProps) => {
 const ViewActionCell = ({ row, isCourseEnabled }: CellProps & Partial<ViewActionCellExtraProps>) => {
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
-  const viewPath = `/authz/user/${row.original.username}`;
+  const viewPath = buildUserPath(row.original.username ?? '');
   const isCourseScope = !row.original.role?.startsWith('lib') && !DJANGO_MANAGED_ROLES.includes(row.original.role);
   const isDisabled = isCourseEnabled !== undefined && isCourseScope && !isCourseEnabled(row.original.scope);
 
@@ -144,7 +145,7 @@ const ScopeCell = ({ row }: CellProps) => {
         iconSrc: RESOURCE_ICONS.GLOBAL,
       };
     }
-    const scopeIcon = row.original.role?.startsWith('lib') ? RESOURCE_ICONS.LIBRARY : RESOURCE_ICONS.COURSE;
+    const scopeIcon = getScopeContextType(row.original.scope) === 'library' ? RESOURCE_ICONS.LIBRARY : RESOURCE_ICONS.COURSE;
     return {
       scopeText: row.original.scope,
       iconSrc: scopeIcon,
@@ -174,10 +175,10 @@ const PermissionsCell = ({ row }: CellProps) => {
   const isDjangoRole = DJANGO_MANAGED_ROLES.includes(role);
   return (
     <span>
-      { isDjangoRole
+      {isDjangoRole
         ? formatMessage(
           messages['authz.user.table.permissions.access.label'],
-          { accessType: role === 'django.superuser' ? 'total' : 'partial' },
+          { accessType: role === SUPERUSER_ROLE ? 'total' : 'partial' },
         )
         : formatMessage(messages['authz.user.table.permissions.available.count'], { count })}
     </span>
@@ -239,7 +240,7 @@ const ActionsCell = ({
           <Tooltip variant="light" id="tooltip-left">
             {formatMessage(messages['authz.user.table.delete.action.djangorole.tooltip'])}
           </Tooltip>
-      )}
+        )}
       >
         <Icon
           className="mx-2 pl-1"
@@ -257,7 +258,7 @@ const ActionsCell = ({
           <Tooltip variant="light" id="tooltip-left">
             {formatMessage(messages['authz.user.table.delete.action.adminrole.tooltip'])}
           </Tooltip>
-      )}
+        )}
       >
         <Icon
           className="mx-2 pl-1 text-light-500"

--- a/src/authz-module/components/TableCells.tsx
+++ b/src/authz-module/components/TableCells.tsx
@@ -8,10 +8,10 @@ import {
 import { UserRoleWithPermissions, RoleToDelete } from '@src/types';
 import { useNavigate } from 'react-router-dom';
 import { useContext, useMemo, type ComponentProps } from 'react';
+import { buildUserPath, getScopeContextType } from '@src/authz-module/constants';
 import {
-  ADMIN_ROLES, buildUserPath, DJANGO_MANAGED_ROLES, getScopeContextType,
-  MAP_ROLE_KEY_TO_LABEL, SUPERUSER_ROLE,
-} from '@src/authz-module/constants';
+  ADMIN_ROLES, DJANGO_MANAGED_ROLES, MAP_ROLE_KEY_TO_LABEL, SUPERUSER_ROLE,
+} from '@src/authz-module/roles-permissions';
 import {
   Icon, IconButton, OverlayTrigger, Tooltip, DataTableContext,
   type DataTableCellProps,

--- a/src/authz-module/components/TableControlBar/ScopesFilter.tsx
+++ b/src/authz-module/components/TableControlBar/ScopesFilter.tsx
@@ -4,7 +4,7 @@ import { LocationOn } from '@openedx/paragon/icons';
 import { useViewTeamPermissions } from '@src/authz-module/hooks/useViewTeamPermissions';
 import { useCourseAuthoringFlag } from '@src/authz-module/hooks/useCourseAuthoringFlag';
 import { useScopes } from '@src/authz-module/data/hooks';
-import { DEFAULT_FILTER_PAGE_SIZE } from '@src/authz-module/constants';
+import { DEFAULT_FILTER_PAGE_SIZE, getScopeContextType } from '@src/authz-module/constants';
 import { MultipleChoiceFilterProps } from './types';
 import MultipleChoiceFilter from './MultipleChoiceFilter';
 import { RESOURCE_ICONS } from '../constants';
@@ -29,13 +29,13 @@ const ScopesFilter = ({
 
   const filterChoices = useMemo(() => (scopesData?.pages?.flatMap((p) => p.results) ?? [])
     // Libraries are always available; courses only when the authoring flag is enabled for them.
-    .filter((scope) => scope.externalKey?.startsWith('lib') || isCourseEnabled(scope.externalKey))
+    .filter((scope) => getScopeContextType(scope.externalKey ?? '') === 'library' || isCourseEnabled(scope.externalKey))
     .map((scope) => {
-      const scopeIcon = scope.externalKey?.startsWith('lib') ? RESOURCE_ICONS.LIBRARY : RESOURCE_ICONS.COURSE;
-      let groupName = formatMessage(messages['authz.team.members.table.group.courses']);
-      if (scope.externalKey?.startsWith('lib')) {
-        groupName = formatMessage(messages['authz.team.members.table.group.libraries']);
-      }
+      const isLibraryScope = getScopeContextType(scope.externalKey ?? '') === 'library';
+      const scopeIcon = isLibraryScope ? RESOURCE_ICONS.LIBRARY : RESOURCE_ICONS.COURSE;
+      const groupName = isLibraryScope
+        ? formatMessage(messages['authz.team.members.table.group.libraries'])
+        : formatMessage(messages['authz.team.members.table.group.courses']);
       return {
         displayName: scope.displayName,
         value: scope.externalKey,

--- a/src/authz-module/components/UserPermissions.tsx
+++ b/src/authz-module/components/UserPermissions.tsx
@@ -1,6 +1,6 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { DJANGO_MANAGED_ROLES } from '@src/authz-module/constants';
 import {
+  DJANGO_MANAGED_ROLES,
   LIBRARY_ROLE_KEYS,
   courseResourceTypes,
   coursePermissions,

--- a/src/authz-module/components/UserPermissions.tsx
+++ b/src/authz-module/components/UserPermissions.tsx
@@ -1,6 +1,7 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { DJANGO_MANAGED_ROLES } from '@src/authz-module/constants';
 import {
+  LIBRARY_ROLE_KEYS,
   courseResourceTypes,
   coursePermissions,
   courseRolesWithPermissions,
@@ -36,7 +37,7 @@ const UserPermissions = ({ row }: UserPermissionsProps) => {
 
   // Normalize role string to match keys in constants (e.g. "Course Admin" -> "course_admin")
   roleKey = roleKey.trim().toLowerCase().replace(/[-\s]+/g, '_');
-  const isLibraryRole = roleKey.includes('library');
+  const isLibraryRole = LIBRARY_ROLE_KEYS.includes(roleKey);
   const config = isLibraryRole
     ? {
       resourceTypes: libraryResourceTypes,

--- a/src/authz-module/components/constants.ts
+++ b/src/authz-module/components/constants.ts
@@ -13,8 +13,8 @@ export const RESOURCE_ICONS = {
 // The API expects the underscore format when roles are sent as filter values,
 // while role data received from the API uses the dotted format (e.g. django.superuser).
 const GLOBAL_ROLE_FILTER_OPTIONS = [
-  { value: 'super_admin', displayName: MAP_ROLE_KEY_TO_LABEL[SUPERUSER_ROLE] },
-  { value: 'global_staff', displayName: MAP_ROLE_KEY_TO_LABEL[GLOBAL_STAFF_ROLE] },
+  { value: 'super_admin', displayName: MAP_ROLE_KEY_TO_LABEL[SUPERUSER_ROLE], contextType: 'global' },
+  { value: 'global_staff', displayName: MAP_ROLE_KEY_TO_LABEL[GLOBAL_STAFF_ROLE], contextType: 'global' },
 ];
 
 export const getRolesFiltersOptions = (intl: IntlShape) => {
@@ -39,6 +39,7 @@ export const getRolesFiltersOptions = (intl: IntlShape) => {
       ...contextGroups[meta.contextType],
       displayName: meta.name,
       value: meta.role,
+      contextType: meta.contextType,
     })),
   ];
 };

--- a/src/authz-module/components/constants.ts
+++ b/src/authz-module/components/constants.ts
@@ -1,84 +1,44 @@
 import type { IntlShape } from '@edx/frontend-platform/i18n';
 import { Language, LibraryBooks, School } from '@openedx/paragon/icons';
+import { allRolesMetadata } from '@src/authz-module/roles-permissions';
+import { GLOBAL_STAFF_ROLE, MAP_ROLE_KEY_TO_LABEL, SUPERUSER_ROLE } from '@src/authz-module/constants';
 import messages from './messages';
-
-export const getRolesFiltersOptions = (intl: IntlShape) => [
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.global']),
-    groupIcon: Language,
-    displayName: 'Super Admin',
-    value: 'super_admin',
-    contextType: 'global',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.global']),
-    groupIcon: Language,
-    displayName: 'Global Staff',
-    value: 'global_staff',
-    contextType: 'global',
-  },
-
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
-    groupIcon: School,
-    displayName: 'Course Admin',
-    value: 'course_admin',
-    contextType: 'course',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
-    groupIcon: School,
-    displayName: 'Course Staff',
-    value: 'course_staff',
-    contextType: 'course',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
-    groupIcon: School,
-    displayName: 'Course Editor',
-    value: 'course_editor',
-    contextType: 'course',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
-    groupIcon: School,
-    displayName: 'Course Auditor',
-    value: 'course_auditor',
-    contextType: 'course',
-  },
-
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.libraries']),
-    groupIcon: LibraryBooks,
-    displayName: 'Library Admin',
-    value: 'library_admin',
-    contextType: 'library',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.libraries']),
-    groupIcon: LibraryBooks,
-    displayName: 'Library Author',
-    value: 'library_author',
-    contextType: 'library',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.libraries']),
-    groupIcon: LibraryBooks,
-    displayName: 'Library Contributor',
-    value: 'library_contributor',
-    contextType: 'library',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.libraries']),
-    groupIcon: LibraryBooks,
-    displayName: 'Library User',
-    value: 'library_user',
-    contextType: 'library',
-  },
-];
 
 export const RESOURCE_ICONS = {
   COURSE: School,
   LIBRARY: LibraryBooks,
   GLOBAL: Language,
+};
+
+// The API expects the underscore format when roles are sent as filter values,
+// while role data received from the API uses the dotted format (e.g. django.superuser).
+const GLOBAL_ROLE_FILTER_OPTIONS = [
+  { value: 'super_admin', displayName: MAP_ROLE_KEY_TO_LABEL[SUPERUSER_ROLE] },
+  { value: 'global_staff', displayName: MAP_ROLE_KEY_TO_LABEL[GLOBAL_STAFF_ROLE] },
+];
+
+export const getRolesFiltersOptions = (intl: IntlShape) => {
+  const globalGroup = {
+    groupName: intl.formatMessage(messages['authz.team.members.table.group.global']),
+    groupIcon: RESOURCE_ICONS.GLOBAL,
+  };
+  const contextGroups = {
+    course: {
+      groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
+      groupIcon: RESOURCE_ICONS.COURSE,
+    },
+    library: {
+      groupName: intl.formatMessage(messages['authz.team.members.table.group.libraries']),
+      groupIcon: RESOURCE_ICONS.LIBRARY,
+    },
+  };
+
+  return [
+    ...GLOBAL_ROLE_FILTER_OPTIONS.map((role) => ({ ...globalGroup, ...role })),
+    ...allRolesMetadata.map((meta) => ({
+      ...contextGroups[meta.contextType],
+      displayName: meta.name,
+      value: meta.role,
+    })),
+  ];
 };

--- a/src/authz-module/components/constants.ts
+++ b/src/authz-module/components/constants.ts
@@ -1,7 +1,8 @@
 import type { IntlShape } from '@edx/frontend-platform/i18n';
 import { Language, LibraryBooks, School } from '@openedx/paragon/icons';
-import { allRolesMetadata } from '@src/authz-module/roles-permissions';
-import { GLOBAL_STAFF_ROLE, MAP_ROLE_KEY_TO_LABEL, SUPERUSER_ROLE } from '@src/authz-module/constants';
+import {
+  allRolesMetadata, GLOBAL_STAFF_ROLE, MAP_ROLE_KEY_TO_LABEL, SUPERUSER_ROLE,
+} from '@src/authz-module/roles-permissions';
 import messages from './messages';
 
 export const RESOURCE_ICONS = {

--- a/src/authz-module/constants.test.ts
+++ b/src/authz-module/constants.test.ts
@@ -1,7 +1,7 @@
+import type { ContextType } from '@src/types';
 import {
-  buildWizardPath, getOrgAggregateScopeKey, getPlatformAggregateScopeKey, ROUTES,
+  buildUserPath, buildWizardPath, getOrgAggregateScopeKey, getPlatformAggregateScopeKey, getScopeContextType, ROUTES,
 } from './constants';
-import type { ContextType } from './constants';
 
 const BASE = `${ROUTES.HOME_PATH}${ROUTES.ASSIGN_ROLE_WIZARD_PATH}`;
 
@@ -33,6 +33,30 @@ describe('buildWizardPath', () => {
 
   it('omits the query string when users and from are both empty strings', () => {
     expect(buildWizardPath({ users: '', from: '' })).toBe(BASE);
+  });
+});
+
+describe('buildUserPath', () => {
+  it('builds the audit-user path for a username', () => {
+    expect(buildUserPath('alice')).toBe(`${ROUTES.HOME_PATH}/user/alice`);
+  });
+
+  it('encodes special characters in the username', () => {
+    expect(buildUserPath('a b@c')).toBe(`${ROUTES.HOME_PATH}/user/a%20b%40c`);
+  });
+});
+
+describe('getScopeContextType', () => {
+  it('returns library for a library scope', () => {
+    expect(getScopeContextType('lib:MIT:intro')).toBe('library');
+  });
+
+  it('returns course for a course scope', () => {
+    expect(getScopeContextType('course-v1:MIT+6.00x+2024')).toBe('course');
+  });
+
+  it('defaults to course for an unrecognized scope', () => {
+    expect(getScopeContextType('MIT')).toBe('course');
   });
 });
 

--- a/src/authz-module/constants.ts
+++ b/src/authz-module/constants.ts
@@ -1,10 +1,11 @@
+import type { ContextType } from '@src/types';
+import { allRolesMetadata } from './roles-permissions';
+
 // Resource Type Definitions
 export const CONTEXT_TYPES = {
   LIBRARY: 'library',
   COURSE: 'course',
 } as const;
-
-export type ContextType = typeof CONTEXT_TYPES[keyof typeof CONTEXT_TYPES];
 
 const ORG_AGGREGATE_SCOPE_BUILDERS = {
   [CONTEXT_TYPES.COURSE]: (orgSlug: string) => `course-v1:${orgSlug}+*`,
@@ -27,21 +28,18 @@ export const getPlatformAggregateScopeKey = (contextType: ContextType): string =
   if (!scope) { throw new Error(`Unknown contextType: "${contextType}"`); }
   return scope;
 };
+export const getScopeContextType = (scope: string): ContextType => (scope.startsWith('lib') ? 'library' : 'course');
 
 export const DEFAULT_TOAST_DELAY = 5000;
 export const RETRY_TOAST_DELAY = 120_000; // 2 minutes
-export const SKELETON_ROWS = Array.from({ length: 10 }).map(() => ({
-  username: 'skeleton',
-  name: '',
-  email: '',
-  roles: [],
-}));
 
 export const ROUTES = {
   HOME_PATH: '/authz',
   AUDIT_USER_PATH: '/user/:username',
   ASSIGN_ROLE_WIZARD_PATH: '/assign-role',
 };
+
+export const buildUserPath = (username: string) => `${ROUTES.HOME_PATH}${ROUTES.AUDIT_USER_PATH.replace(':username', encodeURIComponent(username))}`;
 
 export const buildWizardPath = (options?: { users?: string; from?: string }) => {
   const base = `${ROUTES.HOME_PATH}${ROUTES.ASSIGN_ROLE_WIZARD_PATH}`;
@@ -53,32 +51,18 @@ export const buildWizardPath = (options?: { users?: string; from?: string }) => 
   return query ? `${base}?${query}` : base;
 };
 
-export enum RoleOperationErrorStatus {
-  USER_NOT_FOUND = 'user_not_found',
-  USER_ALREADY_HAS_ROLE = 'user_already_has_role',
-  USER_DOES_NOT_HAVE_ROLE = 'user_does_not_have_role',
-  ROLE_ASSIGNMENT_ERROR = 'role_assignment_error',
-  ROLE_REMOVAL_ERROR = 'role_removal_error',
-}
-
 export const MAX_TABLE_FILTERS_APPLIED = 10;
 
-export const AUTHZ_HOME_PATH = '/authz';
+// Role data received from the API uses the dotted format for Django-managed roles.
+export const SUPERUSER_ROLE = 'django.superuser';
+export const GLOBAL_STAFF_ROLE = 'django.globalstaff';
+export const DJANGO_MANAGED_ROLES = [SUPERUSER_ROLE, GLOBAL_STAFF_ROLE];
 
 export const MAP_ROLE_KEY_TO_LABEL: Record<string, string> = {
-  library_admin: 'Library Admin',
-  library_author: 'Library Author',
-  library_contributor: 'Library Contributor',
-  library_user: 'Library User',
-  course_admin: 'Course Admin',
-  course_staff: 'Course Staff',
-  course_editor: 'Course Editor',
-  course_auditor: 'Course Auditor',
-  'django.superuser': 'Super Admin',
-  'django.globalstaff': 'Global Staff',
+  ...Object.fromEntries(allRolesMetadata.map((meta) => [meta.role, meta.name])),
+  [SUPERUSER_ROLE]: 'Super Admin',
+  [GLOBAL_STAFF_ROLE]: 'Global Staff',
 };
-
-export const DJANGO_MANAGED_ROLES = ['django.superuser', 'django.globalstaff'];
 
 export const TABLE_DEFAULT_PAGE_SIZE = 10;
 

--- a/src/authz-module/constants.ts
+++ b/src/authz-module/constants.ts
@@ -55,7 +55,7 @@ export const MAX_TABLE_FILTERS_APPLIED = 10;
 
 // Role data received from the API uses the dotted format for Django-managed roles.
 export const SUPERUSER_ROLE = 'django.superuser';
-export const GLOBAL_STAFF_ROLE = 'django.globalstaff';
+export const GLOBAL_STAFF_ROLE = 'django.staff';
 export const DJANGO_MANAGED_ROLES = [SUPERUSER_ROLE, GLOBAL_STAFF_ROLE];
 
 export const MAP_ROLE_KEY_TO_LABEL: Record<string, string> = {

--- a/src/authz-module/constants.ts
+++ b/src/authz-module/constants.ts
@@ -1,5 +1,4 @@
 import type { ContextType } from '@src/types';
-import { allRolesMetadata } from './roles-permissions';
 
 // Resource Type Definitions
 export const CONTEXT_TYPES = {
@@ -53,18 +52,6 @@ export const buildWizardPath = (options?: { users?: string; from?: string }) => 
 
 export const MAX_TABLE_FILTERS_APPLIED = 10;
 
-// Role data received from the API uses the dotted format for Django-managed roles.
-export const SUPERUSER_ROLE = 'django.superuser';
-export const GLOBAL_STAFF_ROLE = 'django.staff';
-export const DJANGO_MANAGED_ROLES = [SUPERUSER_ROLE, GLOBAL_STAFF_ROLE];
-
-export const MAP_ROLE_KEY_TO_LABEL: Record<string, string> = {
-  ...Object.fromEntries(allRolesMetadata.map((meta) => [meta.role, meta.name])),
-  [SUPERUSER_ROLE]: 'Super Admin',
-  [GLOBAL_STAFF_ROLE]: 'Global Staff',
-};
-
 export const TABLE_DEFAULT_PAGE_SIZE = 10;
 
 export const DEFAULT_FILTER_PAGE_SIZE = 5;
-export const ADMIN_ROLES = ['course_admin', 'library_admin'];

--- a/src/authz-module/hooks/useQuerySettings.ts
+++ b/src/authz-module/hooks/useQuerySettings.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { QuerySettings } from '@src/authz-module/data/api';
+import { TABLE_DEFAULT_PAGE_SIZE } from '@src/authz-module/constants';
 
 interface DataTableFilters {
   pageSize: number;
@@ -32,7 +33,7 @@ export const useQuerySettings = (
     scopes: null,
     organizations: null,
     search: null,
-    pageSize: 10,
+    pageSize: TABLE_DEFAULT_PAGE_SIZE,
     pageIndex: 0,
     order: null,
     sortBy: null,
@@ -49,7 +50,7 @@ export const useQuerySettings = (
       const scopesFilter = tableFilters.filters?.find((filter) => filter.id === 'scope')?.value?.join(',') ?? '';
 
       // Extract pagination
-      const { pageSize = 10, pageIndex = 0 } = tableFilters;
+      const { pageSize = TABLE_DEFAULT_PAGE_SIZE, pageIndex = 0 } = tableFilters;
 
       // Extract and convert sorting
       let sortByOption = '';

--- a/src/authz-module/role-assignation-wizard/AssignRoleWizardPage.tsx
+++ b/src/authz-module/role-assignation-wizard/AssignRoleWizardPage.tsx
@@ -3,7 +3,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { useValidateUserPermissionsNonSuspense } from '@src/data/hooks';
 import AssignRoleWizard from './AssignRoleWizard';
 import AuthZLayout from '../components/AuthZLayout';
-import { ROUTES } from '../constants';
+import { buildUserPath, ROUTES } from '../constants';
 import messages from './messages';
 import {
   CONTENT_COURSE_PERMISSIONS, CONTENT_LIBRARY_PERMISSIONS, courseRolesMetadata, libraryRolesMetadata,
@@ -21,7 +21,7 @@ const AssignRoleWizardPage = () => {
 
   const presetUser = initialUsers.trim();
   const destination = (presetUser && !presetUser.includes(','))
-    ? `${ROUTES.HOME_PATH}/user/${presetUser}`
+    ? buildUserPath(presetUser)
     : returnTo;
 
   const { data: managePermissions } = useValidateUserPermissionsNonSuspense(MANAGE_TEAM_PERMISSIONS);

--- a/src/authz-module/role-assignation-wizard/components/DefineApplicationScopeStep.tsx
+++ b/src/authz-module/role-assignation-wizard/components/DefineApplicationScopeStep.tsx
@@ -1,16 +1,14 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Alert } from '@openedx/paragon';
-import { courseRolesMetadata } from '@src/authz-module/roles-permissions/course/constants';
-import { libraryRolesMetadata } from '@src/authz-module/roles-permissions/library/constants';
+import { allRolesMetadata } from '@src/authz-module/roles-permissions';
+import type { ContextType } from '@src/types';
 import useScopeListData from '../hooks/useScopeListData';
 import ScopeFilterBar from './ScopeFilterBar';
 import ScopeList from './ScopeList';
 import messages from '../messages';
 
-const allRolesMetadata = [...courseRolesMetadata, ...libraryRolesMetadata];
-
-function getContextType(role: string | null): string | undefined {
+function getContextType(role: string | null): ContextType | undefined {
   if (!role) { return undefined; }
   return allRolesMetadata.find((r) => r.role === role)?.contextType;
 }

--- a/src/authz-module/role-assignation-wizard/components/SelectUsersAndRoleStep.test.tsx
+++ b/src/authz-module/role-assignation-wizard/components/SelectUsersAndRoleStep.test.tsx
@@ -1,27 +1,28 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWrapper } from '@src/setupTest';
+import type { RoleMetadata } from '@src/types';
 import SelectUsersAndRoleStep from './SelectUsersAndRoleStep';
 
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: () => ({ LMS_BASE_URL: 'http://localhost:8000' }),
 }));
 
-const libraryRole = {
+const libraryRole: RoleMetadata = {
   role: 'library_admin',
   name: 'Library Admin',
   description: 'Can manage the library.',
   contextType: 'library',
 };
 
-const courseRole = {
+const courseRole: RoleMetadata = {
   role: 'course_admin',
   name: 'Course Admin',
   description: 'Can manage the course team.',
   contextType: 'course',
 };
 
-const disabledRole = {
+const disabledRole: RoleMetadata = {
   role: 'course_editor',
   name: 'Course Editor',
   description: 'Can edit course content.',

--- a/src/authz-module/role-assignation-wizard/components/SelectUsersAndRoleStep.tsx
+++ b/src/authz-module/role-assignation-wizard/components/SelectUsersAndRoleStep.tsx
@@ -5,7 +5,7 @@ import {
   Tooltip,
 } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
-import { RoleMetadata } from '@src/types';
+import { ContextType, RoleMetadata } from '@src/types';
 import HighlightedUsersInput from './HighlightedUsersInput';
 import messages from '../messages';
 
@@ -19,8 +19,7 @@ interface SelectUsersAndRoleStepProps {
   inputRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
-const CONTEXT_ORDER = ['library', 'course'];
-const ADMIN_URL = `${getConfig().LMS_BASE_URL}/admin`;
+const CONTEXT_ORDER: ContextType[] = ['library', 'course'];
 
 const SelectUsersAndRoleStep = ({
   users,
@@ -123,7 +122,7 @@ const SelectUsersAndRoleStep = ({
         <p className="mb-1 font-weight-bold small">{intl.formatMessage(messages['wizard.step1.docs.heading'])}</p>
         <p className="mb-0 small">
           {intl.formatMessage(messages['wizard.step1.docs.body'])}{' '}
-          <a href={ADMIN_URL} target="_blank" rel="noopener noreferrer">
+          <a href={`${getConfig().LMS_BASE_URL}/admin`} target="_blank" rel="noopener noreferrer">
             {intl.formatMessage(messages['wizard.step1.docs.link'])}
           </a>
         </p>

--- a/src/authz-module/role-assignation-wizard/constants.ts
+++ b/src/authz-module/role-assignation-wizard/constants.ts
@@ -1,3 +1,5 @@
+// Error codes returned by the role-assignment API. Each code has a matching
+// `wizard.save.error.<code>` message in ./messages.ts.
 export const ROLE_ASSIGNMENT_ERRORS = {
   USER_ALREADY_HAS_ROLE: 'user_already_has_role',
   USER_NOT_FOUND: 'user_not_found',

--- a/src/authz-module/role-assignation-wizard/hooks/useScopeListData.ts
+++ b/src/authz-module/role-assignation-wizard/hooks/useScopeListData.ts
@@ -4,7 +4,6 @@ import { ContextType, Scope } from '@src/types';
 import { useOrgs, useScopes } from '@src/authz-module/data/hooks';
 import { useCourseAuthoringFlag } from '@src/authz-module/hooks/useCourseAuthoringFlag';
 import { getOrgAggregateScopeKey, getPlatformAggregateScopeKey } from '@src/authz-module/constants';
-import type { ContextType } from '@src/authz-module/constants';
 import messages from '../messages';
 import useScopePermissions from './useScopePermissions';
 

--- a/src/authz-module/role-assignation-wizard/hooks/useScopeListData.ts
+++ b/src/authz-module/role-assignation-wizard/hooks/useScopeListData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { Scope } from '@src/types';
+import { ContextType, Scope } from '@src/types';
 import { useOrgs, useScopes } from '@src/authz-module/data/hooks';
 import { useCourseAuthoringFlag } from '@src/authz-module/hooks/useCourseAuthoringFlag';
 import { getOrgAggregateScopeKey, getPlatformAggregateScopeKey } from '@src/authz-module/constants';
@@ -9,7 +9,7 @@ import messages from '../messages';
 import useScopePermissions from './useScopePermissions';
 
 interface UseScopeListDataParams {
-  contextType: string | undefined;
+  contextType: ContextType | undefined;
   search: string;
   orgs: string[];
 }

--- a/src/authz-module/role-assignation-wizard/hooks/useScopePermissions.ts
+++ b/src/authz-module/role-assignation-wizard/hooks/useScopePermissions.ts
@@ -3,9 +3,10 @@ import { useValidateUserPermissions } from '@src/data/hooks';
 import { getOrgAggregateScopeKey, getPlatformAggregateScopeKey } from '@src/authz-module/constants';
 import type { ContextType } from '@src/authz-module/constants';
 import { CONTENT_COURSE_PERMISSIONS, CONTENT_LIBRARY_PERMISSIONS } from '@src/authz-module/roles-permissions';
+import type { ContextType } from '@src/types';
 
 interface UseScopePermissionsParams {
-  contextType: string | undefined;
+  contextType: ContextType | undefined;
   orderedOrgs: string[];
 }
 

--- a/src/authz-module/role-assignation-wizard/hooks/useScopePermissions.ts
+++ b/src/authz-module/role-assignation-wizard/hooks/useScopePermissions.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useValidateUserPermissions } from '@src/data/hooks';
 import { getOrgAggregateScopeKey, getPlatformAggregateScopeKey } from '@src/authz-module/constants';
-import type { ContextType } from '@src/authz-module/constants';
 import { CONTENT_COURSE_PERMISSIONS, CONTENT_LIBRARY_PERMISSIONS } from '@src/authz-module/roles-permissions';
 import type { ContextType } from '@src/types';
 

--- a/src/authz-module/role-assignation-wizard/utils.ts
+++ b/src/authz-module/role-assignation-wizard/utils.ts
@@ -5,19 +5,15 @@ import messages from './messages';
 
 type RoleAssignmentError = PutAssignTeamMembersRoleResponse['errors'][number];
 
+const KNOWN_ERRORS: string[] = Object.values(ROLE_ASSIGNMENT_ERRORS);
+
 export const formatRoleAssignmentError = (
   intl: IntlShape,
   e: RoleAssignmentError,
 ): string => {
   const params = { userIdentifier: e.userIdentifier, scope: e.scope };
-  if (e.error === ROLE_ASSIGNMENT_ERRORS.USER_ALREADY_HAS_ROLE) {
-    return intl.formatMessage(messages['wizard.save.error.user_already_has_role'], params);
-  }
-  if (e.error === ROLE_ASSIGNMENT_ERRORS.USER_NOT_FOUND) {
-    return intl.formatMessage(messages['wizard.save.error.user_not_found'], params);
-  }
-  if (e.error === ROLE_ASSIGNMENT_ERRORS.ROLE_ASSIGNMENT_ERROR) {
-    return intl.formatMessage(messages['wizard.save.error.role_assignment_error'], params);
+  if (KNOWN_ERRORS.includes(e.error)) {
+    return intl.formatMessage(messages[`wizard.save.error.${e.error}`], params);
   }
   return intl.formatMessage(messages['wizard.save.error.default'], { ...params, error: e.error });
 };

--- a/src/authz-module/roles-permissions/index.ts
+++ b/src/authz-module/roles-permissions/index.ts
@@ -1,7 +1,6 @@
-import { CONTENT_COURSE_PERMISSIONS } from './course/constants';
-import { CONTENT_LIBRARY_PERMISSIONS, libraryRolesMetadata as _libraryRolesMetadata } from './library/constants';
 import type { RoleMetadata } from '@src/types';
-import { courseRolesMetadata as _courseRolesMetadata } from './course/constants';
+import { CONTENT_COURSE_PERMISSIONS, courseRolesMetadata as _courseRolesMetadata } from './course/constants';
+import { CONTENT_LIBRARY_PERMISSIONS, libraryRolesMetadata as _libraryRolesMetadata } from './library/constants';
 
 export {
   CONTENT_LIBRARY_PERMISSIONS,

--- a/src/authz-module/roles-permissions/index.ts
+++ b/src/authz-module/roles-permissions/index.ts
@@ -31,4 +31,17 @@ export const VIEW_TEAM_PERMISSIONS: { action: string }[] = [
 ];
 export const allRolesMetadata: RoleMetadata[] = [..._courseRolesMetadata, ..._libraryRolesMetadata];
 
+// Role data received from the API uses the dotted format for Django-managed roles.
+export const SUPERUSER_ROLE = 'django.superuser';
+export const GLOBAL_STAFF_ROLE = 'django.staff';
+export const DJANGO_MANAGED_ROLES = [SUPERUSER_ROLE, GLOBAL_STAFF_ROLE];
+
+export const ADMIN_ROLES = ['course_admin', 'library_admin'];
+
+export const MAP_ROLE_KEY_TO_LABEL: Record<string, string> = {
+  ...Object.fromEntries(allRolesMetadata.map((meta) => [meta.role, meta.name])),
+  [SUPERUSER_ROLE]: 'Super Admin',
+  [GLOBAL_STAFF_ROLE]: 'Global Staff',
+};
+
 export { buildPermissionMatrixByResource, getPermissionMetadata } from './utils';

--- a/src/authz-module/roles-permissions/index.ts
+++ b/src/authz-module/roles-permissions/index.ts
@@ -1,5 +1,7 @@
 import { CONTENT_COURSE_PERMISSIONS } from './course/constants';
 import { CONTENT_LIBRARY_PERMISSIONS, libraryRolesMetadata as _libraryRolesMetadata } from './library/constants';
+import type { RoleMetadata } from '@src/types';
+import { courseRolesMetadata as _courseRolesMetadata } from './course/constants';
 
 export {
   CONTENT_LIBRARY_PERMISSIONS,
@@ -28,4 +30,6 @@ export const VIEW_TEAM_PERMISSIONS: { action: string }[] = [
   { action: CONTENT_LIBRARY_PERMISSIONS.VIEW_LIBRARY_TEAM },
   { action: CONTENT_COURSE_PERMISSIONS.VIEW_COURSE_TEAM },
 ];
+export const allRolesMetadata: RoleMetadata[] = [..._courseRolesMetadata, ..._libraryRolesMetadata];
+
 export { buildPermissionMatrixByResource, getPermissionMetadata } from './utils';

--- a/src/authz-module/utils.tsx
+++ b/src/authz-module/utils.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@openedx/paragon';
 import { FilterList } from '@openedx/paragon/icons';
 import { CONTENT_COURSE_PERMISSIONS, CONTENT_LIBRARY_PERMISSIONS } from './roles-permissions';
+import { getScopeContextType } from './constants';
 
 /**
  * Returns a header value for a DataTable column that shows a filter icon
@@ -31,16 +32,11 @@ export const getCellHeader = (columnId: string, columnTitle: string, filtersAppl
   return columnTitle;
 };
 
-export const getScopeManageAction = (scope: string) => {
-  if (scope.startsWith('lib')) {
-    return CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TEAM;
-  }
-  if (scope.startsWith('course')) {
-    return CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TEAM;
-  }
-  // Default fallback or throw error for unknown scopes
-  return CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TEAM;
-};
+export const getScopeManageAction = (scope: string) => (
+  getScopeContextType(scope) === 'library'
+    ? CONTENT_LIBRARY_PERMISSIONS.MANAGE_LIBRARY_TEAM
+    : CONTENT_COURSE_PERMISSIONS.MANAGE_COURSE_TEAM
+);
 
 export const getScopeManageActionPermission = (scope: string) => {
   const action = getScopeManageAction(scope);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,6 @@ export const STATUS_404 = 404;
 
 export const ERROR_STATUS: ErrorStatusCode = {
   [CustomErrors.NO_ACCESS]: [403, 401],
-  [CustomErrors.NOT_FOUND]: [400, 404],
+  [CustomErrors.NOT_FOUND]: [STATUS_400, STATUS_404],
   [CustomErrors.SERVER_ERROR]: [500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,11 +27,13 @@ export interface LibraryMetadata {
   allowPublicRead: boolean;
 }
 
+export type ContextType = 'course' | 'library';
+
 export interface RoleMetadata {
   role: string;
   name: string;
   description: string;
-  contextType: string;
+  contextType: ContextType;
   disabled?: boolean;
 }
 // TODO: remove unnecessary fields when libraries gets removed


### PR DESCRIPTION
## Summary

Establishes a single source of truth for role metadata and route/scope helpers in the authz module, removing duplicated hardcoded role lists and unused constants.

This is the base PR of a larger cleanup; subsequent PR build on top of it (I will open it soon and reference it).

### What & why

- Roles derived from one source. `MAP_ROLE_KEY_TO_LABEL` and `getRolesFiltersOptions` are now generated from `allRolesMetadata` instead of separate lists, so adding/renaming a role only happens in one place.
- Centralized route/scope helpers, instead of inline string checks.
   - Introduces `buildUserPath()`, `getScopeContextType()`, and the `SUPERUSER_ROLE/GLOBAL_STAFF_ROLE/DJANGO_MANAGED_ROLES` constants.
   - Updates `GLOBAL_STAFF_ROLE` to match backend.
  -  Replaces the standalone `AUTHZ_HOME_PATH` with `ROUTES.HOME_PATH`.
- Stronger typing. Adds a` ContextType = 'course' | 'library'` union and applies it to `RoleMetadata.contextType` and the wizard scope hooks, replacing loose string.
- Removes dead constants. Drops `SKELETON_ROWS`, `RoleOperationErrorStatus`, `RESOURCE_TYPES/ResourceType`.
- Move the url for  `ADMIN_URL` inside the component, the value needs to be resolved at runtime otherwise will not redirect properly.
- Straighten the Role validation in `RenderAdminRole` and display the right message. 
- Minor dedup. `formatRoleAssignmentError` now resolves messages via a KNOWN_ERRORS lookup instead of an if-chain.



### AI use acknowledgement 
Supported by Claude Code