### PR TITLE
refactor: add typed getHttpErrorStatus helper and PlatformError type

### DIFF
--- a/src/authz-module/audit-user/index.tsx
+++ b/src/authz-module/audit-user/index.tsx
@@ -16,6 +16,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useUserAccount, useValidateUserPermissionsNonSuspense } from '@src/data/hooks';
 import { LIBRARY_ROLE_KEYS } from '@src/authz-module/roles-permissions';
 import { useViewTeamPermissions } from '@src/authz-module/hooks/useViewTeamPermissions';
+import { getHttpErrorStatus } from '@src/data/utils';
 import baseMessages from '@src/authz-module/messages';
 import AddRoleButton from '@src/authz-module/components/AddRoleButton';
 import {
@@ -25,6 +26,7 @@ import {
 import { useQuerySettings } from '@src/authz-module/hooks/useQuerySettings';
 import { useCourseAuthoringFlag } from '@src/authz-module/hooks/useCourseAuthoringFlag';
 import { useRevokeUserRoles, useUserAssignedRoles } from '@src/authz-module/data/hooks';
+import type { RevokeUserRolesRequest } from '@src/authz-module/data/api';
 import { RoleToDelete } from '@src/types';
 import { useToastManager } from '@src/components/ToastManager/ToastManagerContext';
 import UserPermissions from '@src/authz-module/components/UserPermissions';
@@ -91,8 +93,7 @@ const AuditUserPage = () => {
 
   useEffect(() => {
     if (!user && !isLoadingUser) {
-      // @ts-ignore
-      if (!isErrorUser || errorUser?.customAttributes?.httpErrorStatus === 404) {
+      if (!isErrorUser || getHttpErrorStatus(errorUser) === 404) {
         navigate(AUTHZ_HOME_PATH);
       }
     }
@@ -179,7 +180,7 @@ const AuditUserPage = () => {
       scope: roleToDelete.scope,
     };
 
-    const runRevokeRole = (variables) => {
+    const runRevokeRole = (variables: { data: RevokeUserRolesRequest }) => {
       const variablesData = {
         data: {
           ...variables.data,

--- a/src/authz-module/components/ErrorPage/index.tsx
+++ b/src/authz-module/components/ErrorPage/index.tsx
@@ -8,6 +8,7 @@ import {
 import {
   CustomErrors, ERROR_STATUS, STATUS_400, STATUS_404,
 } from '@src/constants';
+import { getHttpErrorStatus } from '@src/data/utils';
 
 import messages from './messages';
 
@@ -52,7 +53,7 @@ const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
   const intl = useIntl();
   const [reloading, setReloading] = useState(false);
 
-  const errorStatus: number = error?.customAttributes?.httpErrorStatus;
+  const errorStatus = getHttpErrorStatus(error);
   const errorMessage: string = error?.message;
   const {
     title, description, statusCode, showBackButton, showReloadButton,

--- a/src/authz-module/role-assignation-wizard/AssignRoleWizard.tsx
+++ b/src/authz-module/role-assignation-wizard/AssignRoleWizard.tsx
@@ -7,6 +7,7 @@ import {
 } from '@openedx/paragon';
 import { SpinnerSimple } from '@openedx/paragon/icons';
 import { RoleMetadata } from '@src/types';
+import { getHttpErrorStatus } from '@src/data/utils';
 import { useToastManager } from '@src/components/ToastManager/ToastManagerContext';
 import SelectUsersAndRoleStep from './components/SelectUsersAndRoleStep';
 import DefineApplicationScopeStep from './components/DefineApplicationScopeStep';
@@ -135,7 +136,7 @@ const AssignRoleWizard = ({
       }
     } catch (error) {
       // TODO: remove once the backend supports the permissions endpoint without a required scope.
-      if ((error as any)?.customAttributes?.httpErrorStatus === 403) {
+      if (getHttpErrorStatus(error) === 403) {
         showToast({
           message: intl.formatMessage(messages['wizard.save.error.forbidden']),
           type: 'error',

--- a/src/authz-module/role-assignation-wizard/AssignRoleWizard.tsx
+++ b/src/authz-module/role-assignation-wizard/AssignRoleWizard.tsx
@@ -7,7 +7,6 @@ import {
 } from '@openedx/paragon';
 import { SpinnerSimple } from '@openedx/paragon/icons';
 import { RoleMetadata } from '@src/types';
-import { getHttpErrorStatus } from '@src/data/utils';
 import { useToastManager } from '@src/components/ToastManager/ToastManagerContext';
 import SelectUsersAndRoleStep from './components/SelectUsersAndRoleStep';
 import DefineApplicationScopeStep from './components/DefineApplicationScopeStep';
@@ -135,15 +134,7 @@ const AssignRoleWizard = ({
         onClose();
       }
     } catch (error) {
-      // TODO: remove once the backend supports the permissions endpoint without a required scope.
-      if (getHttpErrorStatus(error) === 403) {
-        showToast({
-          message: intl.formatMessage(messages['wizard.save.error.forbidden']),
-          type: 'error',
-        });
-      } else {
-        showErrorToast(error, handleSave);
-      }
+      showErrorToast(error, handleSave);
     }
   };
 

--- a/src/authz-module/role-assignation-wizard/messages.ts
+++ b/src/authz-module/role-assignation-wizard/messages.ts
@@ -98,11 +98,6 @@ const messages = defineMessages({
     defaultMessage: '{userIdentifier} ({scope}): {error}',
     description: 'Fallback error line shown in the toast for unknown role-assignment error codes',
   },
-  'wizard.save.error.forbidden': {
-    id: 'wizard.save.error.forbidden',
-    defaultMessage: 'You do not have permission to perform this assignment.',
-    description: 'Inline error shown in step 2 when the backend returns 403 on role assignment',
-  },
 
   // DefineApplicationScopeStep — filter bar
   'wizard.step2.search.placeholder': {

--- a/src/components/ToastManager/ToastManagerContext.tsx
+++ b/src/components/ToastManager/ToastManagerContext.tsx
@@ -1,11 +1,12 @@
 import {
-  createContext, useContext, useState, useMemo,
+  createContext, useContext, useState, useMemo, useCallback, useEffect, useRef,
 } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Toast } from '@openedx/paragon';
 import messages from '@src/authz-module/messages';
 import { DEFAULT_TOAST_DELAY, RETRY_TOAST_DELAY } from '@src/authz-module/constants';
+import { getHttpErrorStatus } from '@src/data/utils';
 
 type ToastType = 'success' | 'error' | 'error-retry';
 
@@ -33,7 +34,7 @@ const Br = () => <br />;
 
 type ToastManagerContextType = {
   showToast: (toast: Omit<AppToast, 'id'>) => void;
-  showErrorToast: (error, retryFn?: () => void) => void;
+  showErrorToast: (error: unknown, retryFn?: () => void) => void;
   Bold: (chunks: React.ReactNode[]) => JSX.Element;
   Br: () => JSX.Element;
 };
@@ -47,26 +48,33 @@ interface ToastManagerProviderProps {
 export const ToastManagerProvider = ({ children }: ToastManagerProviderProps) => {
   const intl = useIntl();
   const [toasts, setToasts] = useState<(AppToast & { visible: boolean })[]>([]);
+  const removalTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
 
-  const showToast = (toast: Omit<AppToast, 'id'>) => {
+  const showToast = useCallback((toast: Omit<AppToast, 'id'>) => {
     const id = `toast-notification-${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
     const newToast = { ...toast, id, visible: true };
     setToasts(prev => [...prev, newToast]);
-  };
+  }, []);
 
-  const discardToast = (id: string) => {
+  const discardToast = useCallback((id: string) => {
     setToasts(prev => prev.map(t => (t.id === id ? { ...t, visible: false } : t)));
 
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setToasts(prev => prev.filter(t => t.id !== id));
-    }, 5000);
-  };
+    }, DEFAULT_TOAST_DELAY);
+    removalTimers.current.push(timer);
+  }, []);
+
+  // Clear any pending removal timers when the provider unmounts.
+  useEffect(() => () => {
+    removalTimers.current.forEach(clearTimeout);
+  }, []);
 
   const value = useMemo<ToastManagerContextType>(() => {
-    const showErrorToast = (error, retryFn?: () => void) => {
-      logError(error);
-      const errorStatus = error?.customAttributes?.httpErrorStatus;
-      const toastConfig = ERROR_TOAST_MAP[errorStatus] || ERROR_TOAST_MAP.DEFAULT;
+    const showErrorToast = (error: unknown, retryFn?: () => void) => {
+      logError(error as Error);
+      const errorStatus = getHttpErrorStatus(error);
+      const toastConfig = (errorStatus !== undefined && ERROR_TOAST_MAP[errorStatus]) || ERROR_TOAST_MAP.DEFAULT;
       const message = intl.formatMessage(messages[toastConfig.messageId], { Bold, Br });
       /**
        * For retryable errors, we set a longer delay to give users more time to read the message
@@ -90,7 +98,7 @@ export const ToastManagerProvider = ({ children }: ToastManagerProviderProps) =>
       Bold,
       Br,
     });
-  }, [intl]);
+  }, [intl, showToast]);
 
   return (
     <ToastManagerContext.Provider value={value}>

--- a/src/components/ToastManager/ToastManagerContext.tsx
+++ b/src/components/ToastManager/ToastManagerContext.tsx
@@ -48,7 +48,7 @@ interface ToastManagerProviderProps {
 export const ToastManagerProvider = ({ children }: ToastManagerProviderProps) => {
   const intl = useIntl();
   const [toasts, setToasts] = useState<(AppToast & { visible: boolean })[]>([]);
-  const removalTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const removalTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   const showToast = useCallback((toast: Omit<AppToast, 'id'>) => {
     const id = `toast-notification-${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
@@ -59,10 +59,16 @@ export const ToastManagerProvider = ({ children }: ToastManagerProviderProps) =>
   const discardToast = useCallback((id: string) => {
     setToasts(prev => prev.map(t => (t.id === id ? { ...t, visible: false } : t)));
 
+    // If a removal is already pending for this id, don't stack another.
+    if (removalTimers.current.has(id)) {
+      return;
+    }
+
     const timer = setTimeout(() => {
       setToasts(prev => prev.filter(t => t.id !== id));
+      removalTimers.current.delete(id);
     }, DEFAULT_TOAST_DELAY);
-    removalTimers.current.push(timer);
+    removalTimers.current.set(id, timer);
   }, []);
 
   // Clear any pending removal timers when the provider unmounts.

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -2,3 +2,11 @@ import { getConfig } from '@edx/frontend-platform';
 
 export const getApiUrl = (path: string) => `${getConfig().LMS_BASE_URL}${path || ''}`;
 export const getStudioApiUrl = (path: string) => `${getConfig().STUDIO_BASE_URL}${path || ''}`;
+
+/**
+ * Safely reads the HTTP status that @edx/frontend-platform's HTTP client attaches
+ * to thrown errors. Returns `undefined` when no status is present.
+ */
+export const getHttpErrorStatus = (error: unknown): number | undefined => (
+  (error as PlatformError | null | undefined)?.customAttributes?.httpErrorStatus
+);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,19 @@
-// Module augmentations for external libraries.
+// Module augmentations and ambient platform types for external libraries.
 // Application domain types belong in src/types.ts, not here.
 
 export {};
+
+declare global {
+  /**
+   * Error shape produced by @edx/frontend-platform's HTTP client, which attaches
+   * the HTTP status under `customAttributes`. Read it with `getHttpErrorStatus`.
+   */
+  interface PlatformError extends Error {
+    customAttributes?: {
+      httpErrorStatus?: number;
+    };
+  }
+}
 
 declare module '@openedx/paragon' {
   export interface DataTableRow<T> {


### PR DESCRIPTION
### Summary

Consolidates the scattered request error's HTTP status into one typed helper, removing the as any / @ts-ignore / lie-to-the-compiler patterns that were duplicated across the module.

###  What and why

- `getHttpErrorStatus(error: unknown): number | undefined,` which safely reads the status the auth client attaches to thrown errors.
-  `PlatformError` interface that return the AxiosError shape.

Small clean ups

- `ToastManagerContext` clears pending toast-removal timers on unmount and wraps` showToast/discardToast` in `useCallback` (fixes a setState-after-unmount risk and a stale-closure in the context value).
- audit-user typed the previously-implicit-any `runRevokeRole` param (`{ data: RevokeUserRolesRequest }`).
- Remove 403 error in Save button Wizard validation, now that the permissions validation supports scope-less request and the scope list is limited to user management list. 

### AI use acknowledgement 
Supported by Claude Code
