### PR TITLE
feat: drop global roles from role filter

### DIFF
--- a/src/authz-module/components/TableControlBar/TableControlBar.test.tsx
+++ b/src/authz-module/components/TableControlBar/TableControlBar.test.tsx
@@ -90,9 +90,9 @@ describe('TableControlBar', () => {
     const rolesButton = screen.getByText('Select Roles');
     expect(rolesButton).toBeInTheDocument();
     await user.click(rolesButton);
-    const superAdminOption = screen.getByRole('checkbox', { name: /Super Admin/i });
-    expect(superAdminOption).toBeInTheDocument();
-    await user.click(superAdminOption);
+    const courseAdminOption = screen.getByRole('checkbox', { name: /Course Admin/i });
+    expect(courseAdminOption).toBeInTheDocument();
+    await user.click(courseAdminOption);
     expect(contextWithRolesFilter.columns[0].setFilter).toHaveBeenCalled();
   });
 

--- a/src/authz-module/components/constants.ts
+++ b/src/authz-module/components/constants.ts
@@ -4,19 +4,6 @@ import messages from './messages';
 
 export const getRolesFiltersOptions = (intl: IntlShape) => [
   {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.global']),
-    groupIcon: Language,
-    displayName: 'Super Admin',
-    value: 'super_admin',
-  },
-  {
-    groupName: intl.formatMessage(messages['authz.team.members.table.group.global']),
-    groupIcon: Language,
-    displayName: 'Global Staff',
-    value: 'global_staff',
-  },
-
-  {
     groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
     groupIcon: School,
     displayName: 'Course Admin',

--- a/src/authz-module/components/messages.ts
+++ b/src/authz-module/components/messages.ts
@@ -107,11 +107,6 @@ const messages = defineMessages({
     defaultMessage: 'Libraries',
     description: 'Label for the "Libraries" group in the team members table filters',
   },
-  'authz.team.members.table.group.global': {
-    id: 'authz.team.members.table.group.global',
-    defaultMessage: 'Global',
-    description: 'Label for the "Global" group in the team members table filters',
-  },
   'authz.table.controlbar.filters.more.results': {
     id: 'authz.table.controlbar.filters.more.results',
     defaultMessage: 'Search to show more',


### PR DESCRIPTION
## Description

The list endpoint no longer returns django-managed roles (openedx/openedx-authz#345), so these filter options have no effect. Remove Super Admin and Global Staff until proper staff/superuser listing is in place (openedx/openedx-authz#347).