### PR TITLE
fix: filter role assignment wizard scopes by manage-team permission

### DIFF
--- a/src/authz-module/role-assignation-wizard/hooks/useScopeListData.test.ts
+++ b/src/authz-module/role-assignation-wizard/hooks/useScopeListData.test.ts
@@ -327,6 +327,21 @@ describe('useScopeListData', () => {
       }));
     });
 
+    it('restricts scopes to those the user can manage', () => {
+      mockUseScopes.mockReturnValue(makeScopesHook());
+      mockUseOrganizations.mockReturnValue({ data: { results: defaultOrgs } });
+
+      renderHook(() => useScopeListData({
+        contextType: 'course',
+        search: '',
+        orgs: [],
+      }), { wrapper });
+
+      expect(mockUseScopes).toHaveBeenCalledWith(expect.objectContaining({
+        managementPermissionOnly: true,
+      }));
+    });
+
     it('passes search to useScopes when provided', () => {
       mockUseScopes.mockReturnValue(makeScopesHook());
       mockUseOrganizations.mockReturnValue({ data: { results: defaultOrgs } });

--- a/src/authz-module/role-assignation-wizard/hooks/useScopeListData.ts
+++ b/src/authz-module/role-assignation-wizard/hooks/useScopeListData.ts
@@ -33,6 +33,7 @@ const useScopeListData = ({ contextType, search, orgs }: UseScopeListDataParams)
     scopeType: contextType,
     search: search || undefined,
     orgs: orgs.length ? orgs : undefined,
+    managementPermissionOnly: true,
   });
 
   const { data: orgsData } = useOrgs();


### PR DESCRIPTION
# Description

The role assignment wizard's "Where It Applies" step listed every course/library scope regardless of whether the user actually had permission to manage its team.
A user with `course_admin` on Course A but not Course B could select Course B in the wizard and only find out it was invalid at submission, when the backend rejected the request with a generic error toast.

## Changes

**useScopeListData**
- Passes `managementPermissionOnly: true` to `useScopes`, so the scope list request now includes the `management_permission_only` query param the API already supported.

### Context
It solves https://github.com/openedx/openedx-authz/issues/350