### PR TITLE
fix: show name and description for legacy course roles listed in assignments

### DIFF
--- a/src/authz-module/components/TableCells.test.tsx
+++ b/src/authz-module/components/TableCells.test.tsx
@@ -3,6 +3,7 @@ import { initializeMockApp } from '@edx/frontend-platform/testing';
 import { renderWrapper } from '@src/setupTest';
 import userEvent from '@testing-library/user-event';
 import { DataTableContext } from '@openedx/paragon';
+import { unsupportedCourseRolesMetadata } from '@src/authz-module/roles-permissions';
 import {
   NameCell,
   ViewActionCell,
@@ -297,6 +298,24 @@ describe('TableCells Components', () => {
 
       expect(screen.getByText('Library Admin')).toBeInTheDocument();
       expect(mockCell.getCellProps).toHaveBeenCalledWith({ 'data-role': 'Library Admin' });
+    });
+
+    it.each(unsupportedCourseRolesMetadata)('names the $name role, assigned outside this console', ({ role, name }) => {
+      const props = {
+        value: role,
+        cell: mockCell,
+        row: {
+          id: '0',
+          original: {
+            role, org: 'Test Org', scope: 'Test Scope', permissionCount: 1,
+          },
+        },
+        column: { id: 'role' },
+      };
+
+      renderWrapper(<RoleCell {...props} />);
+
+      expect(screen.getByText(name)).toBeInTheDocument();
     });
 
     it('renders empty string for unmapped role', () => {

--- a/src/authz-module/components/UserPermissions.test.tsx
+++ b/src/authz-module/components/UserPermissions.test.tsx
@@ -77,6 +77,25 @@ describe('UserPermissions', () => {
     labels.forEach((label) => expect(label.textContent?.trim()).not.toBe(''));
   });
 
+  describe('unsupported course roles', () => {
+    it.each(coursesConstants.unsupportedCourseRolesMetadata)(
+      'describes what the $name role grants instead of listing permissions',
+      ({ role, description }) => {
+        const props = {
+          row: {
+            original: {
+              role,
+            },
+          },
+        };
+
+        renderWrapper(<UserPermissions {...props} />);
+
+        expect(screen.getByText(description)).toBeInTheDocument();
+      },
+    );
+  });
+
   it('returns null when role is empty', () => {
     const props = {
       row: {

--- a/src/authz-module/components/UserPermissions.tsx
+++ b/src/authz-module/components/UserPermissions.tsx
@@ -8,6 +8,7 @@ import {
   libraryPermissions,
   libraryRolesWithPermissions,
   getPermissionMetadata,
+  unsupportedCourseRolesMetadata,
 } from '@src/authz-module/roles-permissions';
 import RenderPermissionColumn from './RenderPermissionColumn';
 import RenderPermissionInLine from './RenderPermissionInLine';
@@ -36,6 +37,20 @@ const UserPermissions = ({ row }: UserPermissionsProps) => {
 
   // Normalize role string to match keys in constants (e.g. "Course Admin" -> "course_admin")
   roleKey = roleKey.trim().toLowerCase().replace(/[-\s]+/g, '_');
+
+  // Roles that can't be managed from this console have no permission metadata to list,
+  // so describe what the role grants instead.
+  const unsupportedRole = unsupportedCourseRolesMetadata.find(({ role }) => role === roleKey);
+  if (unsupportedRole) {
+    return (
+      <div className="d-flex flex-wrap bg-white px-4 py-4 border border-light-200">
+        <p className="mb-0 text-primary-400 font-weight-light">
+          {unsupportedRole.description}
+        </p>
+      </div>
+    );
+  }
+
   const isLibraryRole = roleKey.includes('library');
   const config = isLibraryRole
     ? {

--- a/src/authz-module/components/constants.ts
+++ b/src/authz-module/components/constants.ts
@@ -1,5 +1,6 @@
 import type { IntlShape } from '@edx/frontend-platform/i18n';
 import { Language, LibraryBooks, School } from '@openedx/paragon/icons';
+import { unsupportedCourseRolesMetadata } from '@src/authz-module/roles-permissions';
 import messages from './messages';
 
 export const getRolesFiltersOptions = (intl: IntlShape) => [
@@ -46,6 +47,14 @@ export const getRolesFiltersOptions = (intl: IntlShape) => [
     value: 'course_auditor',
     contextType: 'course',
   },
+  // Roles assigned outside this console can still show up in the table, so they are filterable too.
+  ...unsupportedCourseRolesMetadata.map(({ role, name }) => ({
+    groupName: intl.formatMessage(messages['authz.team.members.table.group.courses']),
+    groupIcon: School,
+    displayName: name,
+    value: role,
+    contextType: 'course',
+  })),
 
   {
     groupName: intl.formatMessage(messages['authz.team.members.table.group.libraries']),

--- a/src/authz-module/constants.ts
+++ b/src/authz-module/constants.ts
@@ -1,3 +1,5 @@
+import { unsupportedCourseRolesMetadata } from './roles-permissions';
+
 // Resource Type Definitions
 export const CONTEXT_TYPES = {
   LIBRARY: 'library',
@@ -66,6 +68,8 @@ export const MAX_TABLE_FILTERS_APPLIED = 10;
 export const AUTHZ_HOME_PATH = '/authz';
 
 export const MAP_ROLE_KEY_TO_LABEL: Record<string, string> = {
+  // Labels for roles assigned outside this console.
+  ...Object.fromEntries(unsupportedCourseRolesMetadata.map(({ role, name }) => [role, name])),
   library_admin: 'Library Admin',
   library_author: 'Library Author',
   library_contributor: 'Library Contributor',

--- a/src/authz-module/roles-permissions/course/constants.ts
+++ b/src/authz-module/roles-permissions/course/constants.ts
@@ -377,6 +377,44 @@ export const courseRolesMetadata: RoleMetadata[] = [
   },
 ];
 
+// Course roles that exist in openedx-authz but have not yet been migrated.
+// These roles can be listed, but no permissions are defined for them yet,
+// so they are not managed by this console.
+//
+// They are kept separate from `courseRolesMetadata` so they can be
+// removed or promoted to supported roles once the migration is complete.
+
+export const unsupportedCourseRolesMetadata: RoleMetadata[] = [
+  {
+    role: 'course_limited_staff',
+    name: 'Course Limited Staff',
+    description: "Course team members with the Limited Staff role help you manage your course. Limited Staff can enroll and unenroll learners, as well as modify their grades and access all course data. Limited Staff don't have access to your course in Studio. Any users not yet enrolled in the course will be automatically enrolled when added as Limited Staff.",
+    contextType: 'course',
+    disabled: true,
+  },
+  {
+    role: 'course_data_researcher',
+    name: 'Course Data Researcher',
+    description: 'Course Data Researchers can access the data download tab. Any users not yet enrolled in the course will be automatically enrolled when added as Course Data Researcher.',
+    contextType: 'course',
+    disabled: true,
+  },
+  {
+    role: 'course_beta_tester',
+    name: 'Course Beta Tester',
+    description: 'Beta Testers can see course content before other learners. They can make sure that the content works, but have no additional privileges. Any users not yet enrolled in the course will be automatically enrolled when added as Beta Tester.',
+    contextType: 'course',
+    disabled: true,
+  },
+  {
+    role: 'ccx_coach',
+    name: 'CCX Coach',
+    description: 'Legacy "CCX Coach" course role. Grants management of a custom course (CCX) derived from this course.',
+    contextType: 'course',
+    disabled: true,
+  },
+];
+
 // Permission keys granted to each course role.
 const COURSE_ROLE_PERMISSIONS: Record<string, string[]> = {
   course_admin: [

--- a/src/authz-module/roles-permissions/index.ts
+++ b/src/authz-module/roles-permissions/index.ts
@@ -17,6 +17,7 @@ export {
   coursePermissions,
   courseRolesWithPermissions,
   courseRolesMetadata,
+  unsupportedCourseRolesMetadata,
 } from './course/constants';
 
 export const MANAGE_TEAM_PERMISSIONS: { action: string }[] = [


### PR DESCRIPTION
### Description

Course assignments can include roles that exist in openedx-authz but haven't been migrated to the permissions model yet: **course_limited_staff**, **course_data_researcher**, **course_beta_tester** and **ccx_coach**. They reach the admin console through assignments made elsewhere (legacy Instructor Dashboard, course-authoring migration), and the console had no metadata for them, so they rendered as blank rows:

- The Role column fell back to '' because the key wasn't in MAP_ROLE_KEY_TO_LABEL, leaving the assignment unnamed.
- Expanding View all permissions returned null, so the panel opened empty.

This adds the missing metadata and renders it.

<img width="2997" height="711" alt="image" src="https://github.com/user-attachments/assets/bee45660-3acb-4969-bfee-4d46d3af7f1a" />


<img width="3015" height="874" alt="image" src="https://github.com/user-attachments/assets/8dc33acc-d77a-4d5d-a846-71be4db9db43" />


### How to test

1. Assign one of the four roles to a user from the legacy Instructor Dashboard (or seed it directly).
2. Open the admin console user/course assignments table.
3. The Role column shows the role name (e.g. "Course Limited Staff") instead of an empty cell.
4. Expand View all permissions — the panel shows the role description instead of rendering empty.


### Related information

- https://github.com/openedx/frontend-app-admin-console/issues/179